### PR TITLE
Allow blacklist typedef

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -770,6 +770,10 @@ fn ctypedef_to_rs(ctx: &mut GenCtx, ty: TypeInfo) -> Vec<P<ast::Item>> {
             .type_(&rust_name).build_ty(P(rust_ty))
     }
 
+    if ty.hide {
+        return vec![];
+    }
+
     if ty.opaque {
         return mk_opaque_struct(ctx, &ty.name, &ty.layout);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -211,8 +211,10 @@ fn decl_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> Global {
             }
             CXCursor_TypeAliasDecl | CXCursor_TypedefDecl => {
                 let opaque = ctx.options.opaque_types.iter().any(|name| *name == spelling);
+                let hide = ctx.options.blacklist_type.iter().any(|name| *name == spelling);
                 let mut ti = TypeInfo::new(spelling, ctx.current_module_id, TVoid, layout);
                 ti.opaque = opaque;
+                ti.hide = hide;
 
                 let ti = Rc::new(RefCell::new(ti));
                 GType(ti)

--- a/src/types.rs
+++ b/src/types.rs
@@ -821,6 +821,7 @@ pub struct TypeInfo {
     // TODO: Is this really useful?
     // You can just make opaque the underlying type
     pub opaque: bool,
+    pub hide: bool,
 }
 
 impl TypeInfo {
@@ -832,6 +833,7 @@ impl TypeInfo {
             ty: ty,
             layout: layout,
             opaque: false,
+            hide: false,
         }
     }
 }


### PR DESCRIPTION
This allows making type aliases to be blacklisted.