### PR TITLE
Skip -isystem stuff if --target is specified, and don't strip leading _ on Windows

### DIFF
--- a/src/bin/bindgen.rs
+++ b/src/bin/bindgen.rs
@@ -199,11 +199,16 @@ pub fn main() {
             bind_args.push("--".to_owned());
         }
 
-        // TODO: distinguish C and C++ paths? C++'s should be enough, I guess.
-        for path in clang.cpp_search_paths.into_iter() {
-            if let Ok(path) = path.into_os_string().into_string() {
-                bind_args.push("-isystem".to_owned());
-                bind_args.push(path);
+        // If --target is specified, assume caller knows what they're doing and don't mess with
+        // include paths for them
+        let has_target_arg = bind_args.iter().rposition(|arg| arg.starts_with("--target")).is_some();
+        if !has_target_arg {
+            // TODO: distinguish C and C++ paths? C++'s should be enough, I guess.
+            for path in clang.cpp_search_paths.into_iter() {
+                if let Ok(path) = path.into_os_string().into_string() {
+                    bind_args.push("-isystem".to_owned());
+                    bind_args.push(path);
+                }
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -68,13 +68,10 @@ impl<'a> ClangParserCtx<'a> {
     }
 }
 
-fn cursor_link_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> String {
-    let mut mangling = cursor.mangling();
-
+fn cursor_link_name(_: &mut ClangParserCtx, cursor: &Cursor) -> String {
     // Try to undo backend linkage munging (prepended _, generally)
-    if cfg!(target_os = "macos") ||
-       (cfg!(target_os = "windows") && !ctx.options.msvc_mangling)
-    {
+    let mut mangling = cursor.mangling();
+    if cfg!(target_os = "macos") {
         mangling.remove(0);
     }
     mangling


### PR DESCRIPTION
The -isystem stuff fixes issue #53.

Stripping leading _ on Windows is weird; it needs to not be stripped on MSVC (leading @), but on gcc at one point it needed to be.  But now it no longer does.  I don't know.  'cargo test' succeeds with mozjs bindings generated with these fixes.
