### PR TITLE
Take pointer constness into account, to fix generation of const methods.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1423,7 +1423,8 @@ impl ToRustTy for Type {
                 if inner_ty.canonical_type(ctx).is_function() {
                     ty
                 } else {
-                    ty.to_ptr(inner.expect_type().is_const(), ctx.span())
+                    let is_const = self.is_const() || inner.expect_type().is_const();
+                    ty.to_ptr(is_const, ctx.span())
                 }
             }
             TypeKind::Named(..) => {

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -548,8 +548,8 @@ impl CompInfo {
 
                     let default_type =
                         Item::from_ty(&cur.cur_type(), Some(*cur), Some(potential_id), ctx).ok();
-
-                    let param = Item::named_type(cur.spelling(), default_type, potential_id, ctx);
+                    let param = Item::named_type(cur.spelling(), default_type,
+                                                 potential_id, ctx);
                     ci.template_args.push(param);
                 }
                 CXCursor_CXXBaseSpecifier => {

--- a/tests/expectations/class.rs
+++ b/tests/expectations/class.rs
@@ -72,3 +72,52 @@ fn bindgen_test_layout_WithUnion() {
 impl Clone for WithUnion {
     fn clone(&self) -> Self { *self }
 }
+#[repr(C)]
+#[derive(Debug, Copy)]
+pub struct RealAbstractionWithTonsOfMethods {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
+    assert_eq!(::std::mem::size_of::<RealAbstractionWithTonsOfMethods>() ,
+               1usize);
+    assert_eq!(::std::mem::align_of::<RealAbstractionWithTonsOfMethods>() ,
+               1usize);
+}
+extern "C" {
+    #[link_name = "_ZNK32RealAbstractionWithTonsOfMethods3barEv"]
+    pub fn RealAbstractionWithTonsOfMethods_bar(this:
+                                                    *const RealAbstractionWithTonsOfMethods);
+}
+extern "C" {
+    #[link_name = "_ZN32RealAbstractionWithTonsOfMethods3barEv"]
+    pub fn RealAbstractionWithTonsOfMethods_bar1(this:
+                                                     *mut RealAbstractionWithTonsOfMethods);
+}
+extern "C" {
+    #[link_name = "_ZN32RealAbstractionWithTonsOfMethods3barEi"]
+    pub fn RealAbstractionWithTonsOfMethods_bar2(this:
+                                                     *mut RealAbstractionWithTonsOfMethods,
+                                                 foo: ::std::os::raw::c_int);
+}
+extern "C" {
+    #[link_name = "_ZN32RealAbstractionWithTonsOfMethods3staEv"]
+    pub fn RealAbstractionWithTonsOfMethods_sta();
+}
+impl Clone for RealAbstractionWithTonsOfMethods {
+    fn clone(&self) -> Self { *self }
+}
+impl RealAbstractionWithTonsOfMethods {
+    #[inline]
+    pub unsafe fn bar(&self) { RealAbstractionWithTonsOfMethods_bar(&*self) }
+    #[inline]
+    pub unsafe fn bar1(&mut self) {
+        RealAbstractionWithTonsOfMethods_bar1(&mut *self)
+    }
+    #[inline]
+    pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
+        RealAbstractionWithTonsOfMethods_bar2(&mut *self, foo)
+    }
+    #[inline]
+    pub unsafe fn sta() { RealAbstractionWithTonsOfMethods_sta() }
+}

--- a/tests/expectations/const_tparam.rs
+++ b/tests/expectations/const_tparam.rs
@@ -7,5 +7,6 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct C<T> {
-    pub foo: *mut T,
+    pub foo: *const T,
+    pub bar: *mut T,
 }

--- a/tests/headers/class.hpp
+++ b/tests/headers/class.hpp
@@ -18,3 +18,12 @@ union Union {
 class WithUnion {
     Union data;
 };
+
+class RealAbstractionWithTonsOfMethods {
+  void foo();
+public:
+  void bar() const;
+  void bar();
+  void bar(int foo);
+  static void sta();
+};

--- a/tests/headers/const_tparam.hpp
+++ b/tests/headers/const_tparam.hpp
@@ -1,4 +1,5 @@
 template<typename T>
 class C {
   const T* const foo;
+  const T* bar;
 };


### PR DESCRIPTION
We signal method constness in the `this` pointer creating a `const` pointer, but the `to_rust_ty` implementation never checked that.