### PR TITLE
Avoid mangling name for tpl class member. Fix #68

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -56,7 +56,7 @@ impl Cursor {
     }
 
     pub fn mangling(&self) -> String {
-         unsafe {
+        unsafe {
             String_ { x: clang_Cursor_getMangling(self.x) }.to_string()
         }
     }
@@ -134,6 +134,19 @@ impl Cursor {
 
     pub fn is_template(&self) -> bool {
         self.specialized().is_valid()
+    }
+
+    pub fn is_fully_specialized_template(&self) -> bool {
+        self.is_template() && self.num_template_args() > 0
+    }
+
+    pub fn is_in_non_fully_specialized_template(&self) -> bool {
+        if self.is_toplevel() {
+            return false;
+        }
+        let parent = self.semantic_parent();
+        (parent.is_template() && !parent.is_fully_specialized_template()) ||
+            parent.is_in_non_fully_specialized_template()
     }
 
     pub fn is_valid(&self) -> bool {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -75,6 +75,13 @@ fn get_abi(cc: Enum_CXCallingConv) -> abi::Abi {
 }
 
 pub fn cursor_mangling(cursor: &clang::Cursor) -> Option<String> {
+    // We early return here because libclang may crash in some case
+    // if we pass in a variable inside a partial specialized template.
+    // See servo/rust-bindgen#67.
+    if cursor.is_in_non_fully_specialized_template() {
+        return None;
+    }
+
     let mut mangling = cursor.mangling();
 
     // Try to undo backend linkage munging (prepended _, generally)


### PR DESCRIPTION
Not sure whether it is the right thing to do.