### PR TITLE
Use 4 space indentation in run-bindgen.py

### DIFF
--- a/tests/tools/run-bindgen.py
+++ b/tests/tools/run-bindgen.py
@@ -12,24 +12,24 @@ COMMON_PRELUDE = """
 """
 
 if len(sys.argv) != 4:
-  print("Usage: {} [bindgen-path] [c-path] [rust-path]\n".format(sys.argv[0]))
-  sys.exit(1)
+    print("Usage: {} [bindgen-path] [c-path] [rust-path]\n".format(sys.argv[0]))
+    sys.exit(1)
 
 [_, bindgen_path, c_path, rust_path] = sys.argv
 
 flags = ["--no-unstable-rust"]
 
 with open(c_path) as f:
-  for line in f:
-    if line.startswith(BINDGEN_FLAGS_PREFIX):
-      flags.extend(line.strip().split(BINDGEN_FLAGS_PREFIX)[1].split(" "))
-      break
+    for line in f:
+        if line.startswith(BINDGEN_FLAGS_PREFIX):
+            flags.extend(line.strip().split(BINDGEN_FLAGS_PREFIX)[1].split(" "))
+            break
 
 base_command = [bindgen_path, "-o", rust_path]
 
 for line in COMMON_PRELUDE.split("\n"):
-  base_command.append("--raw-line")
-  base_command.append(line)
+    base_command.append("--raw-line")
+    base_command.append(line)
 
 base_command.extend(flags)
 base_command.append(c_path)
@@ -39,31 +39,31 @@ env = os.environ.copy()
 # El Capitan likes to unset dyld variables
 # https://forums.developer.apple.com/thread/9233
 if "DYLD_LIBRARY_PATH" not in env and "LIBCLANG_PATH" in env:
-    env["DYLD_LIBRARY_PATH"] = env["LIBCLANG_PATH"]
+        env["DYLD_LIBRARY_PATH"] = env["LIBCLANG_PATH"]
 
 # If the rust file already exists, read it now so we can compare its contents
 # before and after.
 original_rust_contents = None
 if os.path.isfile(rust_path):
-  with open(rust_path) as f:
-    original_rust_contents = f.read()
+    with open(rust_path) as f:
+        original_rust_contents = f.read()
 
 subprocess.check_call(base_command, cwd=os.getcwd(), env=env)
 
 name = None
 with tempfile.NamedTemporaryFile(delete=False) as tests:
-  name = tests.name
-  subprocess.check_call(["rustc", "--test", sys.argv[3], "-o", tests.name])
+    name = tests.name
+    subprocess.check_call(["rustc", "--test", sys.argv[3], "-o", tests.name])
 subprocess.check_call([tests.name])
 
 if original_rust_contents is not None:
-  new_rust_contents = None
-  with open(rust_path) as f:
-    new_rust_contents = f.read()
-  if new_rust_contents != original_rust_contents:
-    print("Generated rust bindings do not match expectation!")
-    print("Expected rust bindings:")
-    print(original_rust_contents)
-    print("Actual rust bindings:")
-    print(new_rust_contents)
-    sys.exit(1)
+    new_rust_contents = None
+    with open(rust_path) as f:
+        new_rust_contents = f.read()
+    if new_rust_contents != original_rust_contents:
+        print("Generated rust bindings do not match expectation!")
+        print("Expected rust bindings:")
+        print(original_rust_contents)
+        print("Actual rust bindings:")
+        print(new_rust_contents)
+        sys.exit(1)


### PR DESCRIPTION
Python style (PEP8) is 4 space indentation, and you'll be hard pressed
to find anything else in the python community. We should match up with
expectations, editor defaults, etc.

r? @emilio 