### PR TITLE
Give vtables and anonymous items more stable generated names (fixes #60)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ quasi_codegen = "0.20"
 
 [dependencies]
 clang-sys = "0.8.0"
+lazy_static = "0.1.*"
 libc = "0.2"
 log = "0.3"
 env_logger = "0.3"

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -445,8 +445,8 @@ impl<'a> CodeGenerator for Vtable<'a> {
 }
 
 impl<'a> ItemCanonicalName for Vtable<'a> {
-    fn canonical_name(&self, _ctx: &BindgenContext) -> String {
-        format!("bindgen_vtable_{}", self.item_id)
+    fn canonical_name(&self, ctx: &BindgenContext) -> String {
+        format!("{}__bindgen_vtable", self.item_id.canonical_name(ctx))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ extern crate libc;
 extern crate regex;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate lazy_static;
 
 mod clangll;
 mod clang;

--- a/tests/expectations/anon_enum.rs
+++ b/tests/expectations/anon_enum.rs
@@ -10,11 +10,10 @@ pub struct Test {
     pub foo: ::std::os::raw::c_int,
     pub bar: f32,
 }
-pub const Test_T_NONE: Test__bindgen_ty_bindgen_id_6 =
-    Test__bindgen_ty_bindgen_id_6::T_NONE;
+pub const Test_T_NONE: Test__bindgen_ty_1 = Test__bindgen_ty_1::T_NONE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Test__bindgen_ty_bindgen_id_6 { T_NONE = 0, }
+pub enum Test__bindgen_ty_1 { T_NONE = 0, }
 #[test]
 fn bindgen_test_layout_Test() {
     assert_eq!(::std::mem::size_of::<Test>() , 8usize);

--- a/tests/expectations/anon_enum_whitelist.rs
+++ b/tests/expectations/anon_enum_whitelist.rs
@@ -4,10 +4,8 @@
 #![allow(non_snake_case)]
 
 
-pub const NODE_FLAG_FOO: _bindgen_ty_bindgen_id_1 =
-    _bindgen_ty_bindgen_id_1::NODE_FLAG_FOO;
-pub const NODE_FLAG_BAR: _bindgen_ty_bindgen_id_1 =
-    _bindgen_ty_bindgen_id_1::NODE_FLAG_BAR;
+pub const NODE_FLAG_FOO: _bindgen_ty_1 = _bindgen_ty_1::NODE_FLAG_FOO;
+pub const NODE_FLAG_BAR: _bindgen_ty_1 = _bindgen_ty_1::NODE_FLAG_BAR;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum _bindgen_ty_bindgen_id_1 { NODE_FLAG_FOO = 0, NODE_FLAG_BAR = 1, }
+pub enum _bindgen_ty_1 { NODE_FLAG_FOO = 0, NODE_FLAG_BAR = 1, }

--- a/tests/expectations/anon_union.rs
+++ b/tests/expectations/anon_union.rs
@@ -28,7 +28,7 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy, Clone)]
 pub struct TErrorResult<T> {
     pub mResult: ::std::os::raw::c_int,
-    pub __bindgen_anon_1: TErrorResult__bindgen_ty_bindgen_id_10<T>,
+    pub __bindgen_anon_1: TErrorResult__bindgen_ty_1<T>,
     pub mMightHaveUnreported: bool,
     pub mUnionState: TErrorResult_UnionState,
     pub _phantom_0: ::std::marker::PhantomData<T>,
@@ -52,7 +52,7 @@ pub struct TErrorResult_DOMExceptionInfo<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TErrorResult__bindgen_ty_bindgen_id_10<T> {
+pub struct TErrorResult__bindgen_ty_1<T> {
     pub mMessage: __BindgenUnionField<*mut TErrorResult_Message<T>>,
     pub mDOMExceptionInfo: __BindgenUnionField<*mut TErrorResult_DOMExceptionInfo<T>>,
     pub bindgen_union_field: u64,

--- a/tests/expectations/class_with_inner_struct.rs
+++ b/tests/expectations/class_with_inner_struct.rs
@@ -28,8 +28,8 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy)]
 pub struct A {
     pub c: ::std::os::raw::c_uint,
-    pub named_union: A__bindgen_ty_bindgen_id_9,
-    pub __bindgen_anon_1: A__bindgen_ty_bindgen_id_14,
+    pub named_union: A__bindgen_ty_1,
+    pub __bindgen_anon_1: A__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
@@ -47,31 +47,30 @@ impl Clone for A_Segment {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct A__bindgen_ty_bindgen_id_9 {
+pub struct A__bindgen_ty_1 {
     pub f: __BindgenUnionField<::std::os::raw::c_int>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_A__bindgen_ty_bindgen_id_9() {
-    assert_eq!(::std::mem::size_of::<A__bindgen_ty_bindgen_id_9>() , 4usize);
-    assert_eq!(::std::mem::align_of::<A__bindgen_ty_bindgen_id_9>() , 4usize);
+fn bindgen_test_layout_A__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<A__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<A__bindgen_ty_1>() , 4usize);
 }
-impl Clone for A__bindgen_ty_bindgen_id_9 {
+impl Clone for A__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct A__bindgen_ty_bindgen_id_14 {
+pub struct A__bindgen_ty_2 {
     pub d: __BindgenUnionField<::std::os::raw::c_int>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_A__bindgen_ty_bindgen_id_14() {
-    assert_eq!(::std::mem::size_of::<A__bindgen_ty_bindgen_id_14>() , 4usize);
-    assert_eq!(::std::mem::align_of::<A__bindgen_ty_bindgen_id_14>() ,
-               4usize);
+fn bindgen_test_layout_A__bindgen_ty_2() {
+    assert_eq!(::std::mem::size_of::<A__bindgen_ty_2>() , 4usize);
+    assert_eq!(::std::mem::align_of::<A__bindgen_ty_2>() , 4usize);
 }
-impl Clone for A__bindgen_ty_bindgen_id_14 {
+impl Clone for A__bindgen_ty_2 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -121,57 +120,51 @@ pub enum StepSyntax {
 #[derive(Debug, Copy)]
 pub struct C {
     pub d: ::std::os::raw::c_uint,
-    pub __bindgen_anon_1: C__bindgen_ty_bindgen_id_31,
+    pub __bindgen_anon_1: C__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct C__bindgen_ty_bindgen_id_31 {
-    pub mFunc: __BindgenUnionField<C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_32>,
-    pub __bindgen_anon_1: __BindgenUnionField<C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_43>,
+pub struct C__bindgen_ty_1 {
+    pub mFunc: __BindgenUnionField<C__bindgen_ty_1_1>,
+    pub __bindgen_anon_1: __BindgenUnionField<C__bindgen_ty_1_2>,
     pub bindgen_union_field: [u32; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_32 {
+pub struct C__bindgen_ty_1_1 {
     pub mX1: f32,
     pub mY1: f32,
     pub mX2: f32,
     pub mY2: f32,
 }
 #[test]
-fn bindgen_test_layout_C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_32() {
-    assert_eq!(::std::mem::size_of::<C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_32>()
-               , 16usize);
-    assert_eq!(::std::mem::align_of::<C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_32>()
-               , 4usize);
+fn bindgen_test_layout_C__bindgen_ty_1_1() {
+    assert_eq!(::std::mem::size_of::<C__bindgen_ty_1_1>() , 16usize);
+    assert_eq!(::std::mem::align_of::<C__bindgen_ty_1_1>() , 4usize);
 }
-impl Clone for C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_32 {
+impl Clone for C__bindgen_ty_1_1 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_43 {
+pub struct C__bindgen_ty_1_2 {
     pub mStepSyntax: StepSyntax,
     pub mSteps: ::std::os::raw::c_uint,
 }
 #[test]
-fn bindgen_test_layout_C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_43() {
-    assert_eq!(::std::mem::size_of::<C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_43>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_43>()
-               , 4usize);
+fn bindgen_test_layout_C__bindgen_ty_1_2() {
+    assert_eq!(::std::mem::size_of::<C__bindgen_ty_1_2>() , 8usize);
+    assert_eq!(::std::mem::align_of::<C__bindgen_ty_1_2>() , 4usize);
 }
-impl Clone for C__bindgen_ty_bindgen_id_31__bindgen_ty_bindgen_id_43 {
+impl Clone for C__bindgen_ty_1_2 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_C__bindgen_ty_bindgen_id_31() {
-    assert_eq!(::std::mem::size_of::<C__bindgen_ty_bindgen_id_31>() ,
-               16usize);
-    assert_eq!(::std::mem::align_of::<C__bindgen_ty_bindgen_id_31>() ,
-               4usize);
+fn bindgen_test_layout_C__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<C__bindgen_ty_1>() , 16usize);
+    assert_eq!(::std::mem::align_of::<C__bindgen_ty_1>() , 4usize);
 }
-impl Clone for C__bindgen_ty_bindgen_id_31 {
+impl Clone for C__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]

--- a/tests/expectations/const_enum_unnamed.rs
+++ b/tests/expectations/const_enum_unnamed.rs
@@ -4,23 +4,20 @@
 #![allow(non_snake_case)]
 
 
-pub const FOO_BAR: _bindgen_ty_bindgen_id_1 =
-    _bindgen_ty_bindgen_id_1::FOO_BAR;
-pub const FOO_BAZ: _bindgen_ty_bindgen_id_1 =
-    _bindgen_ty_bindgen_id_1::FOO_BAZ;
+pub const FOO_BAR: _bindgen_ty_1 = _bindgen_ty_1::FOO_BAR;
+pub const FOO_BAZ: _bindgen_ty_1 = _bindgen_ty_1::FOO_BAZ;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum _bindgen_ty_bindgen_id_1 { FOO_BAR = 0, FOO_BAZ = 1, }
+pub enum _bindgen_ty_1 { FOO_BAR = 0, FOO_BAZ = 1, }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct Foo {
     pub _address: u8,
 }
-pub const Foo_FOO_BAR: Foo__bindgen_ty_bindgen_id_5 =
-    Foo__bindgen_ty_bindgen_id_5::FOO_BAR;
+pub const Foo_FOO_BAR: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::FOO_BAR;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Foo__bindgen_ty_bindgen_id_5 { FOO_BAR = 10, }
+pub enum Foo__bindgen_ty_1 { FOO_BAR = 10, }
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(::std::mem::size_of::<Foo>() , 1usize);

--- a/tests/expectations/enum_and_vtable_mangling.rs
+++ b/tests/expectations/enum_and_vtable_mangling.rs
@@ -4,19 +4,18 @@
 #![allow(non_snake_case)]
 
 
-pub const match_: _bindgen_ty_bindgen_id_1 = _bindgen_ty_bindgen_id_1::match_;
-pub const whatever_else: _bindgen_ty_bindgen_id_1 =
-    _bindgen_ty_bindgen_id_1::whatever_else;
+pub const match_: _bindgen_ty_1 = _bindgen_ty_1::match_;
+pub const whatever_else: _bindgen_ty_1 = _bindgen_ty_1::whatever_else;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum _bindgen_ty_bindgen_id_1 { match_ = 0, whatever_else = 1, }
+pub enum _bindgen_ty_1 { match_ = 0, whatever_else = 1, }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_4 {
+pub struct C__bindgen_vtable {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct C {
-    pub vtable_: *const bindgen_vtable__bindgen_id_4,
+    pub vtable_: *const C__bindgen_vtable,
     pub i: ::std::os::raw::c_int,
 }
 #[test]

--- a/tests/expectations/jsval_layout_opaque.rs
+++ b/tests/expectations/jsval_layout_opaque.rs
@@ -94,8 +94,8 @@ pub enum JSWhyMagic {
 #[derive(Debug, Copy)]
 pub struct jsval_layout {
     pub asBits: __BindgenUnionField<u64>,
-    pub debugView: __BindgenUnionField<jsval_layout__bindgen_ty_bindgen_id_90>,
-    pub s: __BindgenUnionField<jsval_layout__bindgen_ty_bindgen_id_97>,
+    pub debugView: __BindgenUnionField<jsval_layout__bindgen_ty_1>,
+    pub s: __BindgenUnionField<jsval_layout__bindgen_ty_2>,
     pub asDouble: __BindgenUnionField<f64>,
     pub asPtr: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub asWord: __BindgenUnionField<usize>,
@@ -104,20 +104,18 @@ pub struct jsval_layout {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct jsval_layout__bindgen_ty_bindgen_id_90 {
+pub struct jsval_layout__bindgen_ty_1 {
     pub _bitfield_1: u64,
 }
 #[test]
-fn bindgen_test_layout_jsval_layout__bindgen_ty_bindgen_id_90() {
-    assert_eq!(::std::mem::size_of::<jsval_layout__bindgen_ty_bindgen_id_90>()
-               , 8usize);
-    assert_eq!(::std::mem::align_of::<jsval_layout__bindgen_ty_bindgen_id_90>()
-               , 8usize);
+fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<jsval_layout__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<jsval_layout__bindgen_ty_1>() , 8usize);
 }
-impl Clone for jsval_layout__bindgen_ty_bindgen_id_90 {
+impl Clone for jsval_layout__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
-impl jsval_layout__bindgen_ty_bindgen_id_90 {
+impl jsval_layout__bindgen_ty_1 {
     #[inline]
     pub fn payload47(&self) -> u64 {
         unsafe {
@@ -150,36 +148,33 @@ impl jsval_layout__bindgen_ty_bindgen_id_90 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct jsval_layout__bindgen_ty_bindgen_id_97 {
-    pub payload: jsval_layout__bindgen_ty_bindgen_id_97__bindgen_ty_bindgen_id_98,
+pub struct jsval_layout__bindgen_ty_2 {
+    pub payload: jsval_layout__bindgen_ty_2_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct jsval_layout__bindgen_ty_bindgen_id_97__bindgen_ty_bindgen_id_98 {
+pub struct jsval_layout__bindgen_ty_2_1 {
     pub i32: __BindgenUnionField<i32>,
     pub u32: __BindgenUnionField<u32>,
     pub why: __BindgenUnionField<JSWhyMagic>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_jsval_layout__bindgen_ty_bindgen_id_97__bindgen_ty_bindgen_id_98() {
-    assert_eq!(::std::mem::size_of::<jsval_layout__bindgen_ty_bindgen_id_97__bindgen_ty_bindgen_id_98>()
-               , 4usize);
-    assert_eq!(::std::mem::align_of::<jsval_layout__bindgen_ty_bindgen_id_97__bindgen_ty_bindgen_id_98>()
-               , 4usize);
+fn bindgen_test_layout_jsval_layout__bindgen_ty_2_1() {
+    assert_eq!(::std::mem::size_of::<jsval_layout__bindgen_ty_2_1>() ,
+               4usize);
+    assert_eq!(::std::mem::align_of::<jsval_layout__bindgen_ty_2_1>() ,
+               4usize);
 }
-impl Clone for
- jsval_layout__bindgen_ty_bindgen_id_97__bindgen_ty_bindgen_id_98 {
+impl Clone for jsval_layout__bindgen_ty_2_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_jsval_layout__bindgen_ty_bindgen_id_97() {
-    assert_eq!(::std::mem::size_of::<jsval_layout__bindgen_ty_bindgen_id_97>()
-               , 4usize);
-    assert_eq!(::std::mem::align_of::<jsval_layout__bindgen_ty_bindgen_id_97>()
-               , 4usize);
+fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
+    assert_eq!(::std::mem::size_of::<jsval_layout__bindgen_ty_2>() , 4usize);
+    assert_eq!(::std::mem::align_of::<jsval_layout__bindgen_ty_2>() , 4usize);
 }
-impl Clone for jsval_layout__bindgen_ty_bindgen_id_97 {
+impl Clone for jsval_layout__bindgen_ty_2 {
     fn clone(&self) -> Self { *self }
 }
 impl Clone for jsval_layout {

--- a/tests/expectations/namespace.rs
+++ b/tests/expectations/namespace.rs
@@ -18,7 +18,7 @@ pub mod root {
             pub fn in_whatever();
         }
     }
-    pub mod _bindgen_mod_bindgen_id_13 {
+    pub mod _bindgen_mod_id_13 {
         use root;
         pub mod empty {
             use root;
@@ -44,7 +44,7 @@ pub mod root {
     #[repr(C)]
     #[derive(Debug)]
     pub struct C<T> {
-        pub _base: root::_bindgen_mod_bindgen_id_13::A,
+        pub _base: root::_bindgen_mod_id_13::A,
         pub m_c: T,
         pub m_c_ptr: *mut T,
         pub m_c_arr: [T; 10usize],
@@ -78,7 +78,7 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug)]
 pub struct C<T> {
-    pub _base: root::_bindgen_mod_bindgen_id_13::A,
+    pub _base: root::_bindgen_mod_id_13::A,
     pub m_c: T,
     pub m_c_ptr: *mut T,
     pub m_c_arr: [T; 10usize],

--- a/tests/expectations/nested_vtable.rs
+++ b/tests/expectations/nested_vtable.rs
@@ -5,12 +5,12 @@
 
 
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_1 {
+pub struct nsISupports__bindgen_vtable {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsISupports {
-    pub vtable_: *const bindgen_vtable__bindgen_id_1,
+    pub vtable_: *const nsISupports__bindgen_vtable,
 }
 #[test]
 fn bindgen_test_layout_nsISupports() {

--- a/tests/expectations/ref_argument_array.rs
+++ b/tests/expectations/ref_argument_array.rs
@@ -6,12 +6,12 @@
 
 pub const NSID_LENGTH: ::std::os::raw::c_uint = 10;
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_4 {
+pub struct nsID__bindgen_vtable {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsID {
-    pub vtable_: *const bindgen_vtable__bindgen_id_4,
+    pub vtable_: *const nsID__bindgen_vtable,
 }
 #[test]
 fn bindgen_test_layout_nsID() {

--- a/tests/expectations/struct_with_anon_struct.rs
+++ b/tests/expectations/struct_with_anon_struct.rs
@@ -7,22 +7,20 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: foo__bindgen_ty_bindgen_id_2,
+    pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_anon_struct_array.rs
+++ b/tests/expectations/struct_with_anon_struct_array.rs
@@ -7,39 +7,35 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: [foo__bindgen_ty_bindgen_id_2; 2usize],
-    pub baz: [[[foo__bindgen_ty_bindgen_id_8; 4usize]; 3usize]; 2usize],
+    pub bar: [foo__bindgen_ty_1; 2usize],
+    pub baz: [[[foo__bindgen_ty_2; 4usize]; 3usize]; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_8 {
+pub struct foo__bindgen_ty_2 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_8() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_8>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_8>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_2() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_2>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_2>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_8 {
+impl Clone for foo__bindgen_ty_2 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/struct_with_anon_struct_pointer.rs
@@ -7,22 +7,20 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: *mut foo__bindgen_ty_bindgen_id_2,
+    pub bar: *mut foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_anon_union.rs
+++ b/tests/expectations/struct_with_anon_union.rs
@@ -27,23 +27,21 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: foo__bindgen_ty_bindgen_id_2,
+    pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: __BindgenUnionField<::std::os::raw::c_uint>,
     pub b: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/struct_with_anon_unnamed_struct.rs
@@ -7,22 +7,20 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub __bindgen_anon_1: foo__bindgen_ty_bindgen_id_2,
+    pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/struct_with_anon_unnamed_union.rs
@@ -27,23 +27,21 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub __bindgen_anon_1: foo__bindgen_ty_bindgen_id_2,
+    pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: __BindgenUnionField<::std::os::raw::c_uint>,
     pub b: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_nesting.rs
+++ b/tests/expectations/struct_with_nesting.rs
@@ -28,58 +28,52 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy)]
 pub struct foo {
     pub a: ::std::os::raw::c_uint,
-    pub __bindgen_anon_1: foo__bindgen_ty_bindgen_id_4,
+    pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4 {
+pub struct foo__bindgen_ty_1 {
     pub b: __BindgenUnionField<::std::os::raw::c_uint>,
-    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_7>,
-    pub __bindgen_anon_2: __BindgenUnionField<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_12>,
+    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_1_1>,
+    pub __bindgen_anon_2: __BindgenUnionField<foo__bindgen_ty_1_2>,
     pub bindgen_union_field: u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_7 {
+pub struct foo__bindgen_ty_1_1 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_7() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_7>()
-               , 4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_7>()
-               , 2usize);
+fn bindgen_test_layout_foo__bindgen_ty_1_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1_1>() , 2usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_7 {
+impl Clone for foo__bindgen_ty_1_1 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_12 {
+pub struct foo__bindgen_ty_1_2 {
     pub d1: ::std::os::raw::c_uchar,
     pub d2: ::std::os::raw::c_uchar,
     pub d3: ::std::os::raw::c_uchar,
     pub d4: ::std::os::raw::c_uchar,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_12() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_12>()
-               , 4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_12>()
-               , 1usize);
+fn bindgen_test_layout_foo__bindgen_ty_1_2() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1_2>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1_2>() , 1usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_12 {
+impl Clone for foo__bindgen_ty_1_2 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/struct_with_struct.rs
+++ b/tests/expectations/struct_with_struct.rs
@@ -7,22 +7,20 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: foo__bindgen_ty_bindgen_id_2,
+    pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub x: ::std::os::raw::c_uint,
     pub y: ::std::os::raw::c_uint,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/typeref.rs
+++ b/tests/expectations/typeref.rs
@@ -79,12 +79,12 @@ impl Clone for Bar {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleShapeSource<ReferenceBox> {
-    pub __bindgen_anon_1: StyleShapeSource__bindgen_ty_bindgen_id_14<ReferenceBox>,
+    pub __bindgen_anon_1: StyleShapeSource__bindgen_ty_1<ReferenceBox>,
     pub _phantom_0: ::std::marker::PhantomData<ReferenceBox>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct StyleShapeSource__bindgen_ty_bindgen_id_14<ReferenceBox> {
+pub struct StyleShapeSource__bindgen_ty_1<ReferenceBox> {
     pub mPosition: __BindgenUnionField<*mut Position>,
     pub mFragmentOrURL: __BindgenUnionField<*mut FragmentOrURL>,
     pub bindgen_union_field: u64,

--- a/tests/expectations/union_fields.rs
+++ b/tests/expectations/union_fields.rs
@@ -26,18 +26,18 @@ impl <T> ::std::clone::Clone for __BindgenUnionField<T> {
 impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct _bindgen_ty_bindgen_id_1 {
+pub struct _bindgen_ty_1 {
     pub mInt: __BindgenUnionField<::std::os::raw::c_int>,
     pub mFloat: __BindgenUnionField<f32>,
     pub mPointer: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout__bindgen_ty_bindgen_id_1() {
-    assert_eq!(::std::mem::size_of::<_bindgen_ty_bindgen_id_1>() , 8usize);
-    assert_eq!(::std::mem::align_of::<_bindgen_ty_bindgen_id_1>() , 8usize);
+fn bindgen_test_layout__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<_bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<_bindgen_ty_1>() , 8usize);
 }
-impl Clone for _bindgen_ty_bindgen_id_1 {
+impl Clone for _bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
-pub type nsStyleUnion = _bindgen_ty_bindgen_id_1;
+pub type nsStyleUnion = _bindgen_ty_1;

--- a/tests/expectations/union_template.rs
+++ b/tests/expectations/union_template.rs
@@ -28,13 +28,13 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy, Clone)]
 pub struct NastyStruct<T> {
     pub mIsSome: bool,
-    pub mStorage: NastyStruct__bindgen_ty_bindgen_id_6<T>,
-    pub __bindgen_anon_1: NastyStruct__bindgen_ty_bindgen_id_12<T>,
+    pub mStorage: NastyStruct__bindgen_ty_1<T>,
+    pub __bindgen_anon_1: NastyStruct__bindgen_ty_2<T>,
     pub _phantom_0: ::std::marker::PhantomData<T>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct NastyStruct__bindgen_ty_bindgen_id_6<T> {
+pub struct NastyStruct__bindgen_ty_1<T> {
     pub mFoo: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub mDummy: __BindgenUnionField<::std::os::raw::c_ulong>,
     pub bindgen_union_field: u64,
@@ -42,7 +42,7 @@ pub struct NastyStruct__bindgen_ty_bindgen_id_6<T> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct NastyStruct__bindgen_ty_bindgen_id_12<T> {
+pub struct NastyStruct__bindgen_ty_2<T> {
     pub wat: __BindgenUnionField<::std::os::raw::c_short>,
     pub wut: __BindgenUnionField<*mut ::std::os::raw::c_int>,
     pub bindgen_union_field: u64,

--- a/tests/expectations/union_with_anon_struct.rs
+++ b/tests/expectations/union_with_anon_struct.rs
@@ -27,23 +27,21 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: __BindgenUnionField<foo__bindgen_ty_bindgen_id_2>,
+    pub bar: __BindgenUnionField<foo__bindgen_ty_1>,
     pub bindgen_union_field: [u32; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               8usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 8usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/union_with_anon_struct_bitfield.rs
@@ -28,25 +28,23 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy)]
 pub struct foo {
     pub a: __BindgenUnionField<::std::os::raw::c_int>,
-    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_bindgen_id_4>,
+    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_1>,
     pub bindgen_union_field: u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4 {
+pub struct foo__bindgen_ty_1 {
     pub _bitfield_1: u32,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
-impl foo__bindgen_ty_bindgen_id_4 {
+impl foo__bindgen_ty_1 {
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_int {
         unsafe {

--- a/tests/expectations/union_with_anon_union.rs
+++ b/tests/expectations/union_with_anon_union.rs
@@ -27,24 +27,22 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct foo {
-    pub bar: __BindgenUnionField<foo__bindgen_ty_bindgen_id_2>,
+    pub bar: __BindgenUnionField<foo__bindgen_ty_1>,
     pub bindgen_union_field: u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_2 {
+pub struct foo__bindgen_ty_1 {
     pub a: __BindgenUnionField<::std::os::raw::c_uint>,
     pub b: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_2() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_2>() ,
-               4usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 4usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_2 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/union_with_anon_unnamed_struct.rs
@@ -28,25 +28,23 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy)]
 pub struct pixel {
     pub rgba: __BindgenUnionField<::std::os::raw::c_uint>,
-    pub __bindgen_anon_1: __BindgenUnionField<pixel__bindgen_ty_bindgen_id_4>,
+    pub __bindgen_anon_1: __BindgenUnionField<pixel__bindgen_ty_1>,
     pub bindgen_union_field: u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct pixel__bindgen_ty_bindgen_id_4 {
+pub struct pixel__bindgen_ty_1 {
     pub r: ::std::os::raw::c_uchar,
     pub g: ::std::os::raw::c_uchar,
     pub b: ::std::os::raw::c_uchar,
     pub a: ::std::os::raw::c_uchar,
 }
 #[test]
-fn bindgen_test_layout_pixel__bindgen_ty_bindgen_id_4() {
-    assert_eq!(::std::mem::size_of::<pixel__bindgen_ty_bindgen_id_4>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<pixel__bindgen_ty_bindgen_id_4>() ,
-               1usize);
+fn bindgen_test_layout_pixel__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<pixel__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<pixel__bindgen_ty_1>() , 1usize);
 }
-impl Clone for pixel__bindgen_ty_bindgen_id_4 {
+impl Clone for pixel__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/union_with_anon_unnamed_union.rs
@@ -28,24 +28,22 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy)]
 pub struct foo {
     pub a: __BindgenUnionField<::std::os::raw::c_uint>,
-    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_bindgen_id_4>,
+    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_1>,
     pub bindgen_union_field: u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4 {
+pub struct foo__bindgen_ty_1 {
     pub b: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub c: __BindgenUnionField<::std::os::raw::c_uchar>,
     pub bindgen_union_field: u16,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               2usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               2usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 2usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 2usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/union_with_nesting.rs
+++ b/tests/expectations/union_with_nesting.rs
@@ -28,57 +28,51 @@ impl <T> ::std::marker::Copy for __BindgenUnionField<T> { }
 #[derive(Debug, Copy)]
 pub struct foo {
     pub a: __BindgenUnionField<::std::os::raw::c_uint>,
-    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_bindgen_id_4>,
+    pub __bindgen_anon_1: __BindgenUnionField<foo__bindgen_ty_1>,
     pub bindgen_union_field: u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4 {
-    pub __bindgen_anon_1: foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_5,
-    pub __bindgen_anon_2: foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_10,
+pub struct foo__bindgen_ty_1 {
+    pub __bindgen_anon_1: foo__bindgen_ty_1_1,
+    pub __bindgen_anon_2: foo__bindgen_ty_1_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_5 {
+pub struct foo__bindgen_ty_1_1 {
     pub b1: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub b2: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub bindgen_union_field: u16,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_5() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_5>()
-               , 2usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_5>()
-               , 2usize);
+fn bindgen_test_layout_foo__bindgen_ty_1_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1_1>() , 2usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1_1>() , 2usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_5 {
+impl Clone for foo__bindgen_ty_1_1 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_10 {
+pub struct foo__bindgen_ty_1_2 {
     pub c1: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub c2: __BindgenUnionField<::std::os::raw::c_ushort>,
     pub bindgen_union_field: u16,
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_10() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_10>()
-               , 2usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_10>()
-               , 2usize);
+fn bindgen_test_layout_foo__bindgen_ty_1_2() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1_2>() , 2usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1_2>() , 2usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4__bindgen_ty_bindgen_id_10 {
+impl Clone for foo__bindgen_ty_1_2 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_foo__bindgen_ty_bindgen_id_4() {
-    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               4usize);
-    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_bindgen_id_4>() ,
-               2usize);
+fn bindgen_test_layout_foo__bindgen_ty_1() {
+    assert_eq!(::std::mem::size_of::<foo__bindgen_ty_1>() , 4usize);
+    assert_eq!(::std::mem::align_of::<foo__bindgen_ty_1>() , 2usize);
 }
-impl Clone for foo__bindgen_ty_bindgen_id_4 {
+impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/tests/expectations/unknown_attr.rs
+++ b/tests/expectations/unknown_attr.rs
@@ -6,11 +6,11 @@
 
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct _bindgen_ty_bindgen_id_1 {
+pub struct _bindgen_ty_1 {
     pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
     pub __clang_max_align_nonce2: f64,
 }
-impl Clone for _bindgen_ty_bindgen_id_1 {
+impl Clone for _bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
-pub type max_align_t = _bindgen_ty_bindgen_id_1;
+pub type max_align_t = _bindgen_ty_1;

--- a/tests/expectations/virtual_dtor.rs
+++ b/tests/expectations/virtual_dtor.rs
@@ -5,12 +5,12 @@
 
 
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_1 {
+pub struct nsSlots__bindgen_vtable {
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsSlots {
-    pub vtable_: *const bindgen_vtable__bindgen_id_1,
+    pub vtable_: *const nsSlots__bindgen_vtable,
 }
 #[test]
 fn bindgen_test_layout_nsSlots() {

--- a/tests/expectations/virtual_overloaded.rs
+++ b/tests/expectations/virtual_overloaded.rs
@@ -5,12 +5,12 @@
 
 
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_1 {
+pub struct C__bindgen_vtable {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct C {
-    pub vtable_: *const bindgen_vtable__bindgen_id_1,
+    pub vtable_: *const C__bindgen_vtable,
 }
 #[test]
 fn bindgen_test_layout_C() {

--- a/tests/expectations/vtable_recursive_sig.rs
+++ b/tests/expectations/vtable_recursive_sig.rs
@@ -18,12 +18,12 @@ impl Clone for Derived {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_2 {
+pub struct Base__bindgen_vtable {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct Base {
-    pub vtable_: *const bindgen_vtable__bindgen_id_2,
+    pub vtable_: *const Base__bindgen_vtable,
 }
 #[test]
 fn bindgen_test_layout_Base() {


### PR DESCRIPTION
r? @emilio 

This works pretty well.  There are two remaining things in stylo's structs files that have identifiers that look like they won't be that stable: the anonymous enum for the NODE_* flags at the top level, and the `typedef union { ... } nsStyleUnion`.  There are various anonymous enums and other things at the top level in system headers that cause these identifiers to have generated IDs in them higher than 1 and 2.

Probably for anonymous enums we could just avoid generating a rust enum altogether, since having the static consts should be sufficient.  I tried to mess with the codegen to automatically treat `typedef union { ... } nsStyleUnion` like `union nsStyleUnion { ... }` but it seems the way clang exposes the typedef and union are as two adjacent cursors rather than a parent-child relationship, so it's not so easy.