### PR TITLE
fix: clang::Cursor::num_args should return Option<u32> #132

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -393,7 +393,7 @@ impl Cursor {
     /// parameters.
     pub fn args(&self) -> Vec<Cursor> {
         unsafe {
-            let num = self.num_args() as usize;
+            let num = self.num_args().expect("expected value, got none") as u32;
             let mut args = vec![];
             for i in 0..num {
                 args.push(Cursor { x: clang_Cursor_getArgument(self.x, i as c_uint) });
@@ -415,9 +415,14 @@ impl Cursor {
     ///
     /// Returns -1 if the cursor's referent is not a function/method call or
     /// declaration.
-    pub fn num_args(&self) -> i32 {
+    pub fn num_args(&self) -> Option<u32> {
         unsafe {
-            clang_Cursor_getNumArguments(self.x)
+            let w = clang_Cursor_getNumArguments(self.x);
+            if w == -1 {
+                None
+            } else {
+                Some(w as u32)
+            }
         }
     }
 

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -415,13 +415,13 @@ impl Cursor {
     ///
     /// Returns -1 if the cursor's referent is not a function/method call or
     /// declaration.
-    pub fn num_args(&self) -> Option<u32> {
+    pub fn num_args(&self) -> Result<u32, ()> {
         unsafe {
             let w = clang_Cursor_getNumArguments(self.x);
             if w == -1 {
-                None
+                Err(())
             } else {
-                Some(w as u32)
+                Ok(w as u32)
             }
         }
     }


### PR DESCRIPTION
Hi, tried to fix the issue mentioned. Not sure, if changing fn args makes sense (the err message probably doesn't...). cargo test --features llvm_stable was succesful.
- changed output of fn num_args to option<u32>
- changed fn args to handle option<u32> instead of usize

