### PR TITLE
#144 Changed `clang::TranslationUnit::parse` to return an Option

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -919,7 +919,7 @@ impl fmt::Debug for TranslationUnit {
 impl TranslationUnit {
     /// Parse a source file into a translation unit.
     pub fn parse(ix: &Index, file: &str, cmd_args: &[String],
-                 unsaved: &[UnsavedFile], opts: ::libc::c_uint) -> TranslationUnit {
+                 unsaved: &[UnsavedFile], opts: ::libc::c_uint) -> Option<TranslationUnit> {
         let fname = CString::new(file).unwrap();
         let _c_args: Vec<CString> = cmd_args.iter().map(|s| CString::new(s.clone()).unwrap()).collect();
         let c_args: Vec<*const c_char> = _c_args.iter().map(|s| s.as_ptr()).collect();
@@ -932,7 +932,11 @@ impl TranslationUnit {
                                        c_unsaved.len() as c_uint,
                                        opts)
         };
-        TranslationUnit { x: tu }
+        if tu.is_null() {
+            None
+        } else {
+            Some(TranslationUnit { x: tu })
+        }
     }
 
     /// Reparse this translation unit, maybe because the file changed on disk or

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -104,7 +104,8 @@ impl<'ctx> BindgenContext<'ctx> {
 
         let translation_unit =
             clang::TranslationUnit::parse(&index, "", &options.clang_args, &[],
-                                          clangll::CXTranslationUnit_DetailedPreprocessingRecord);
+                                          clangll::CXTranslationUnit_DetailedPreprocessingRecord)
+                                          .expect("null TranslationUnit received from `clang::TranslationUnit::parse`");
 
         let root_module = Self::build_root_module();
         let mut me = BindgenContext {


### PR DESCRIPTION
Changed the potentially null pointer to an Optional.

The caller previously assumed the pointer was always valid and not null, so I called `expect` to make it fail early if it isn't.

Fixes #144.