### PR TITLE
Run test in serial by default to not take all memory

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -85,16 +85,15 @@ fn run_bindgen_tests() {
         }
     });
 
-    // First spawn all child processes and collect them, then wait on each
-    // one. This runs the tests in parallel rather than serially.
+    // Spawn one child at a time and wait on it as number of process
+    // is the number of test files.
 
-    let children: Vec<_> = tests.map(|entry| {
-            let child = spawn_run_bindgen(run_bindgen.clone(), bindgen.clone(), entry.path());
-            (entry.path(), child)
-        })
-        .collect();
+    let children = tests.map(|entry| {
+        let child = spawn_run_bindgen(run_bindgen.clone(), bindgen.clone(), entry.path());
+        (entry.path(), child)
+    });
 
-    let failures: Vec<_> = children.into_iter()
+    let failures: Vec<_> = children
         .filter_map(|(path, mut child)| {
             let passed = child.wait()
                 .expect("Should wait on child process")


### PR DESCRIPTION
When running all the test in parallel, all the memory on my laptop
is consumed by rustc processes, my machine become unusable and the
tests do not make progress.

It seems to make sense to have serial by default, as the number of
process depends on the number of test files.

To run the test in parallel:
RUN_TEST_PARALLEL=1 cargo test --feature llvm_stable


This is a first approach at this issue, I'm still really new to rust.
I was trying to run the test for an easy fix, but it was killing my machine.

Ideally it would have been nice to be able to control exactly how many
process to run in parallel, maybe using chunks somewhere. I could try
to see if I can work it out if it would be a better solution.