### PR TITLE
Check bounds when calling Comment::get_child (fix #142)

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -793,9 +793,11 @@ impl Comment {
     }
 
     /// Get this comment's `idx`th child comment
-    pub fn get_child(&self, idx: c_uint) -> Comment {
-        unsafe {
-            Comment { x: clang_Comment_getChild(self.x, idx) }
+    pub fn get_child(&self, idx: c_uint) -> Option<Comment> {
+        if idx  >= self.num_children() {
+            None
+        } else {
+            Some(Comment { x: unsafe { clang_Comment_getChild(self.x, idx) } })
         }
     }
 

--- a/src/ir/annotations.rs
+++ b/src/ir/annotations.rs
@@ -153,7 +153,7 @@ impl Annotations {
         }
 
         for i in 0..comment.num_children() {
-            self.parse(&comment.get_child(i), matched);
+            self.parse(&comment.get_child(i).unwrap(), matched);
         }
     }
 }


### PR DESCRIPTION
Fixes #142.