### PR TITLE
Return Option<Type> in clang::Type::ret_type fix #141

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -714,9 +714,12 @@ impl Type {
 
     /// Given that this type is a function type, get the type of its return
     /// value.
-    pub fn ret_type(&self) -> Type {
-        unsafe {
-            Type { x: clang_getResultType(self.x) }
+    pub fn ret_type(&self) -> Option<Type> {
+        let rt = Type { x: unsafe { clang_getResultType(self.x) } };
+        if rt.kind() == CXType_Invalid {
+            None
+        } else {
+            Some(rt)
         }
     }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -186,7 +186,8 @@ impl FunctionSig {
             }
         }
 
-        let ret = try!(Item::from_ty(&ty.ret_type(), None, None, ctx));
+        let ty_ret_type = try!(ty.ret_type().ok_or(ParseError::Continue));
+        let ret = try!(Item::from_ty(&ty_ret_type, None, None, ctx));
         let abi = get_abi(ty.call_conv());
 
         Ok(Self::new(ret, args, ty.is_variadic(), abi))

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -499,7 +499,7 @@ impl Type {
                 // tests/headers/func_ptr_in_struct.h), so we do a
                 // guess here trying to see if it has a valid return
                 // type.
-                if ty.ret_type().kind() != CXType_Invalid {
+                if ty.ret_type().is_some() {
                     let signature =
                         try!(FunctionSig::from_ty(ty, &location.unwrap_or(cursor), ctx));
                     TypeKind::Function(signature)


### PR DESCRIPTION
Fixes #141 