### PR TITLE
Use iterators for comment children and attributes fix #166

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -791,19 +791,12 @@ impl Comment {
         }
     }
 
-    /// Get the number of children this comment node has.
-    pub fn num_children(&self) -> c_uint {
-        unsafe {
-            clang_Comment_getNumChildren(self.x)
-        }
-    }
-
-    /// Get this comment's `idx`th child comment
-    pub fn get_child(&self, idx: c_uint) -> Option<Comment> {
-        if idx  >= self.num_children() {
-            None
-        } else {
-            Some(Comment { x: unsafe { clang_Comment_getChild(self.x, idx) } })
+    /// Get this comment's children comment
+    pub fn get_children(&self) -> CommentChildrenIterator {
+        CommentChildrenIterator {
+            parent: self.x,
+            length: unsafe { clang_Comment_getNumChildren(self.x) },
+            index: 0
         }
     }
 
@@ -848,6 +841,26 @@ impl Comment {
                     x: clang_HTMLStartTag_getAttrValue(self.x, idx)
                 }.to_string())
             }
+        }
+    }
+}
+
+/// An iterator for a comment's children
+pub struct CommentChildrenIterator {
+    parent: CXComment,
+    length: c_uint,
+    index: c_uint
+}
+
+impl Iterator for CommentChildrenIterator {
+    type Item = Comment;
+    fn next(&mut self) -> Option<Comment> {
+        if self.index < self.length {
+            let idx = self.index;
+            self.index += 1;
+            Some( Comment { x: unsafe { clang_Comment_getChild(self.parent, idx) } } )
+        } else {
+            None
         }
     }
 }

--- a/src/ir/annotations.rs
+++ b/src/ir/annotations.rs
@@ -153,8 +153,8 @@ impl Annotations {
             }
         }
 
-        for i in 0..comment.num_children() {
-            self.parse(&comment.get_child(i).unwrap(), matched);
+        for child in comment.get_children() {
+            self.parse(&child, matched);
         }
     }
 }

--- a/src/ir/annotations.rs
+++ b/src/ir/annotations.rs
@@ -133,21 +133,17 @@ impl Annotations {
         use clangll::CXComment_HTMLStartTag;
         if comment.kind() == CXComment_HTMLStartTag &&
            comment.get_tag_name() == "div" &&
-           comment.get_num_tag_attrs() > 1 &&
-           comment.get_tag_attr_name(0).as_ref().map(|s| s.as_str())
-               == Some("rustbindgen") {
+           comment.get_tag_attrs().next().map_or(false, |attr| attr.name == "rustbindgen") {
             *matched = true;
-            for i in 0..comment.get_num_tag_attrs() {
-                let value_opt = comment.get_tag_attr_value(i);
-                match comment.get_tag_attr_name(i).unwrap().as_str() {
+            for attr in comment.get_tag_attrs() {
+                match attr.name.as_str() {
                     "opaque" => self.opaque = true,
                     "hide" => self.hide = true,
                     "nocopy" => self.disallow_copy = true,
-                    "replaces" => self.use_instead_of = value_opt,
-                    "private" => self.private_fields = value_opt.map(|v|
-                        v != "false"),
-                    "accessor" => self.accessor_kind = value_opt.map(|v|
-                        parse_accessor(&v)),
+                    "replaces" => self.use_instead_of = Some(attr.value),
+                    "private" => self.private_fields = Some(attr.value != "false"),
+                    "accessor"
+                        => self.accessor_kind = Some(parse_accessor(&attr.value)),
                     _ => {},
                 }
             }


### PR DESCRIPTION
Fix #166
