### PR TITLE
clang::Type::num_template_args return Option<u32> fix #135

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -645,19 +645,22 @@ impl Type {
     }
 
     /// If this type is a class template specialization, return its number of
-    /// template arguments. Otherwise, return -1.
-    pub fn num_template_args(&self) -> c_int {
-        unsafe {
-            clang_Type_getNumTemplateArguments(self.x)
+    /// template arguments. Otherwise, return None.
+    pub fn num_template_args(&self) -> Option<u32> {
+        let n = unsafe { clang_Type_getNumTemplateArguments(self.x) };
+        if n >= 0 {
+            Some(n as u32)
+        } else {
+            debug_assert_eq!(n, -1);
+            None
         }
     }
 
     /// Get the type of the `i`th template argument for this template
     /// specialization.
-    pub fn template_arg_type(&self, i: c_int) -> Type {
-        unsafe {
-            Type { x: clang_Type_getTemplateArgumentAsType(self.x, i) }
-        }
+    pub fn template_arg_type(&self, i: u32) -> Type {
+        let n = i as c_int;
+        Type { x: unsafe { clang_Type_getTemplateArgumentAsType(self.x, n) } }
     }
 
     /// Given that this type is a pointer type, return the type that it points

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -492,8 +492,8 @@ impl CompInfo {
         ci.template_args = match ty.num_template_args() {
             // In forward declarations and not specializations, etc, they are in
             // the ast, we'll meet them in CXCursor_TemplateTypeParameter
-            -1 => vec![],
-            len => {
+            None => vec![],
+            Some(len) => {
                 let mut list = Vec::with_capacity(len as usize);
                 for i in 0..len {
                     let arg_type = ty.template_arg_type(i);

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -506,7 +506,7 @@ impl Type {
                     TypeKind::Function(signature)
                 // Same here, with template specialisations we can safely assume
                 // this is a Comp(..)
-                } else if ty.num_template_args() > 0 {
+                } else if ty.num_template_args().unwrap_or(0) > 0 {
                     debug!("Template specialization: {:?}", ty);
                     let complex =
                         CompInfo::from_ty(potential_id, ty, location, ctx)


### PR DESCRIPTION
Fix #135 
