### PR TITLE
Run tests on release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ before_script:
 script:
   - cargo build --verbose --features llvm_stable
   - cargo test --features llvm_stable
+  - cargo build --release --verbose --features llvm_stable
+  - cargo test --release --features llvm_stable
   - git add -A
   - git diff @
   - git diff-index --quiet HEAD

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -64,7 +64,11 @@ fn run_bindgen_tests() {
 
     let mut bindgen = PathBuf::from(&crate_root);
     bindgen.push("target");
-    bindgen.push("debug");
+    if cfg!(debug_assertions) {
+        bindgen.push("debug");
+    } else {
+        bindgen.push("release");
+    }
     bindgen.push("bindgen");
     if !bindgen.is_file() {
         panic!("{} is not a file! Build bindgen before running tests.",


### PR DESCRIPTION
This makes `cargo test` test the appropriate release/debug bindgen binary and extends Travis CI testing to also test release builds.

r? @emilio 