### PR TITLE
Move the `TypeCollector` trait to the `ir` module

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -32,7 +32,7 @@ enum TypeKey {
 // context.
 struct GenContext<'ctx>(ExtCtxt<'ctx>);
 
-impl<'ctx> fmt::Debug for GenContext <'ctx> {
+impl<'ctx> fmt::Debug for GenContext<'ctx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "GenContext {{ ... }}")
     }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -1,8 +1,9 @@
 //! Intermediate representation for C/C++ functions and methods.
 
+use super::context::BindgenContext;
 use super::item::{Item, ItemId};
 use super::ty::TypeKind;
-use super::context::BindgenContext;
+use super::type_collector::{ItemSet, TypeCollector};
 use syntax::abi;
 use clang;
 use clangll::Enum_CXCallingConv;
@@ -244,5 +245,20 @@ impl ClangSubItemParser for Function {
 
         let function = Self::new(name, mangled_name, sig, comment);
         Ok(ParseResult::New(function, Some(cursor)))
+    }
+}
+
+impl TypeCollector for FunctionSig {
+    type Extra = Item;
+
+    fn collect_types(&self,
+                     context: &BindgenContext,
+                     types: &mut ItemSet,
+                     _item: &Item) {
+        self.return_type().collect_types(context, types, &());
+
+        for &(_, ty) in self.argument_types() {
+            ty.collect_types(context, types, &());
+        }
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -14,4 +14,5 @@ pub mod item_kind;
 pub mod layout;
 pub mod module;
 pub mod ty;
+pub mod type_collector;
 pub mod var;

--- a/src/ir/type_collector.rs
+++ b/src/ir/type_collector.rs
@@ -1,0 +1,23 @@
+//! Collecting type items.
+
+use std::collections::BTreeSet;
+use super::context::BindgenContext;
+use super::item::ItemId;
+
+/// A set of items.
+pub type ItemSet = BTreeSet<ItemId>;
+
+/// Collect all the type items referenced by this item.
+pub trait TypeCollector {
+    /// If a particular type needs extra information beyond what it has in
+    /// `self` and `context` to find its referenced type items, its
+    /// implementation can define this associated type, forcing callers to pass
+    /// the needed information through.
+    type Extra;
+
+    /// Add each type item referenced by `self` into the `types` set.
+    fn collect_types(&self,
+                     context: &BindgenContext,
+                     types: &mut ItemSet,
+                     extra: &Self::Extra);
+}


### PR DESCRIPTION
This commit move the `TypeCollector` trait out from the `codegen` module and into its own submodule in `ir::type_collector`. Additionally, it puts the various `TypeCollector` trait implementations next to the types that each implementation is for.

I'm going to start using this trait outside of codegen, and I think it makes more sense in `ir` since it is implemented by `ir` types and is all about `ir` things.

r? @emilio 