### PR TITLE
Fix for #138 : rework for elem_type() which now returns Option<Type> instead of Type

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -673,9 +673,12 @@ impl Type {
 
     /// Given that this type is an array, vector, or complex type, return the
     /// type of its elements.
-    pub fn elem_type(&self) -> Type {
-        unsafe {
-            Type { x: clang_getElementType(self.x) }
+    pub fn elem_type(&self) -> Option<Type> {
+        let current_type = Type { x: unsafe { clang_getElementType(self.x) } };
+        if current_type.kind() != CXType_Invalid {
+            Some(current_type)
+        } else {
+            None
         }
     }
 

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -662,7 +662,9 @@ impl Type {
             CXType_VariableArray |
             CXType_DependentSizedArray |
             CXType_IncompleteArray => {
-                let inner = Item::from_ty(&ty.elem_type(), location, parent_id, ctx)
+                let inner = Item::from_ty(ty.elem_type().as_ref()
+                                          .expect("Not an appropriate type?"),
+                                          location, parent_id, ctx)
                                 .expect("Not able to resolve array element?");
                 TypeKind::Pointer(inner)
             }
@@ -694,14 +696,18 @@ impl Type {
             // That being said, that should be fixed eventually.
             CXType_Vector |
             CXType_ConstantArray => {
-                let inner = Item::from_ty(&ty.elem_type(), location, parent_id, ctx)
+                let inner = Item::from_ty(ty.elem_type().as_ref()
+                                          .expect("Not an appropriate type?"),
+                                          location, parent_id, ctx)
                                 .expect("Not able to resolve array element?");
                 TypeKind::Array(inner, ty.num_elements().unwrap())
             }
             // A complex number is always a real and an imaginary part, so
             // represent that as a two-item array.
             CXType_Complex => {
-                let inner = Item::from_ty(&ty.elem_type(), location, parent_id, ctx)
+                let inner = Item::from_ty(ty.elem_type().as_ref()
+                                          .expect("Not an appropriate type?"),
+                                          location, parent_id, ctx)
                                 .expect("Not able to resolve array element?");
                 TypeKind::Array(inner, 2)
             }


### PR DESCRIPTION
Fixes #138 
Since I am new to Rust, I hope I didn't do things too badly