### PR TITLE
tests: Get rid of feature-specific tests.

### DIFF
--- a/tests/headers/class_with_typedef.hpp
+++ b/tests/headers/class_with_typedef.hpp
@@ -1,5 +1,3 @@
-// bindgen-features: llvm_stable
-
 typedef int AnotherInt;
 
 class C {
@@ -12,10 +10,10 @@ public:
     AnotherInt d;
     AnotherInt* other_ptr;
 
-    void method(MyInt c) {};
-    void methodRef(MyInt& c) {};
-    void complexMethodRef(Lookup& c) {};
-    void anotherMethod(AnotherInt c) {};
+    void method(MyInt c);
+    void methodRef(MyInt& c);
+    void complexMethodRef(Lookup& c);
+    void anotherMethod(AnotherInt c);
 };
 
 class D: public C {


### PR DESCRIPTION
The only difference in bindings is because the methods were inlined, so with
llvm 3.9 we can skip those.