### PR TITLE
Factor out the collection and traversal of the transitive closure of whitelisted items

### DIFF
--- a/tests/expectations/type_alias_empty.rs
+++ b/tests/expectations/type_alias_empty.rs
@@ -4,4 +4,4 @@
 #![allow(non_snake_case)]
 
 
-
+pub type bool_constant = ();

--- a/tests/tools/run-bindgen.py
+++ b/tests/tools/run-bindgen.py
@@ -69,6 +69,7 @@ def parse_args():
 def make_bindgen_env():
     """Build the environment to run bindgen in."""
     env = os.environ.copy()
+    env["RUST_BACKTRACE"] = "1"
 
     # El Capitan likes to unset dyld variables
     # https://forums.developer.apple.com/thread/9233


### PR DESCRIPTION
I'm going to re-use this stuff, plus I think it is way more understandable when pulled out of `codegen`.

This did have the unfortunate consequence of changing iteration order of types, resulting in different anonymous bindgen names for things like unions and such. We *could* sort the whitelisted item set before codegen to alleviate this kind of thing in the future, but I'm not sure it is worth the extra overhead...

r? @emilio 