### PR TITLE
Avoid an extra lookup when finding new whitelisted items to traverse

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -922,9 +922,8 @@ impl<'ctx, 'gen> Iterator for WhitelistedItemsIter<'ctx, 'gen>
         id.collect_types(self.ctx, &mut sub_types, &());
 
         for id in sub_types {
-            if !self.seen.contains(&id) {
+            if self.seen.insert(id) {
                 self.to_iterate.push(id);
-                self.seen.insert(id);
             }
         }
 


### PR DESCRIPTION
`insert()` returns `true` if the item was *not* in the set before, so we can use that to avoid a double lookup.

r? @emilio 