### PR TITLE
Re-introduce docopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ quasi_codegen = "0.20"
 [dependencies]
 cfg-if = "0.1.0"
 clang-sys = "0.8.0"
+docopt = "0.6"
 lazy_static = "0.1.*"
 libc = "0.2"
 log = "0.3"

--- a/src/bin/bindgen.rs
+++ b/src/bin/bindgen.rs
@@ -82,8 +82,8 @@ Options:
 
 Deprecated:
 
-    --use-msvc-mangling           Handle MSVC C++ ABI mangling; requires that
-                                  target be set to (i686|x86_64)-pc-win32.
+    --use-msvc-mangling           MSVC C++ ABI mangling. This is now detected
+                                  automagically.
 ";
 
 pub fn main() {

--- a/src/bin/bindgen.rs
+++ b/src/bin/bindgen.rs
@@ -154,13 +154,13 @@ pub fn main() {
 
     // Input header
     let header = args.get_str("<input-header>");
-    if header != "" {
+    if !header.is_empty() {
         builder = builder.header(header);
     }
 
     // Output file or stdout
     let output = args.get_str("--output");
-    let out = if output != "" {
+    let out = if !output.is_empty() {
         let path = path::Path::new(output);
         let file = fs::File::create(path).expect("Opening output file failed.");
         Box::new(io::BufWriter::new(file)) as Box<io::Write>
@@ -170,7 +170,7 @@ pub fn main() {
 
     // Emit C/C++ type uses file for testing
     let dummy_uses = args.get_str("--dummy-uses");
-    if dummy_uses != "" {
+    if !dummy_uses.is_empty() {
         builder = builder.dummy_uses(dummy_uses);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,9 +301,6 @@ pub struct BindgenOptions {
     /// namespaces.
     pub namespaced_constants: bool,
 
-    /// True if we should use MSVC name mangling rules.
-    pub msvc_mangling: bool,
-
     /// The set of raw lines to prepend to the generated Rust code.
     pub raw_lines: Vec<String>,
 
@@ -335,7 +332,6 @@ impl Default for BindgenOptions {
             enable_cxx_namespaces: false,
             unstable_rust: true,
             namespaced_constants: true,
-            msvc_mangling: false,
             raw_lines: vec![],
             clang_args: vec![],
             input_header: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,30 @@ impl Builder {
         self
     }
 
+    /// Emit Clang AST.
+    pub fn emit_clang_ast(mut self) -> Builder {
+        self.options.emit_ast = true;
+        self
+    }
+
+    /// Enable C++ namespaces.
+    pub fn enable_cxx_namespaces(mut self) -> Builder {
+        self.options.enable_cxx_namespaces = true;
+        self
+    }
+
+    /// Ignore functions.
+    pub fn ignore_functions(mut self) -> Builder {
+        self.options.ignore_functions = true;
+        self
+    }
+
+    /// Ignore methods.
+    pub fn ignore_methods(mut self) -> Builder {
+        self.options.ignore_methods = true;
+        self
+    }
+
     /// Avoid generating any unstable Rust in the generated bindings.
     pub fn no_unstable_rust(mut self) -> Builder {
         self.options.unstable_rust = false;


### PR DESCRIPTION
Fixes servo/rust-bindgen#87.

- Tidy up usage string
- Switch to using bindgen::Builder directly in main()
- Builder required some new methods
- `--use-msvc-mangling` appears to be deprecated, and is only referenced
in `src/lib.rs`. I have added a Deprecated section to the usage string
so using the flag doesn't cause errors
- `--emit-clang-ast` doesn't currently disable output of Rust bindings,
might have to do something tricky here
- Added `--version` based on CARGO_PKG_*
- Need to add some error handling to `<input-header>`