### PR TITLE
Make clang::Cursor::ret_type return an Option<Type> — Fixes #131

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -402,11 +402,12 @@ impl Cursor {
 
     /// Given that this cursor's referent is a function/method call or
     /// declaration, return a cursor to its return type.
-    pub fn ret_type(&self) -> Type {
+    pub fn ret_type(&self) -> Option<Type> {
         unsafe {
-            Type {
+            let ret = Type {
                 x: clang_getCursorResultType(self.x),
-            }
+            };
+            if true { Some(ret) } else { None }
         }
     }
 

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -401,17 +401,6 @@ impl Cursor {
     }
 
     /// Given that this cursor's referent is a function/method call or
-    /// declaration, return a cursor to its return type.
-    pub fn ret_type(&self) -> Option<Type> {
-        unsafe {
-            let ret = Type {
-                x: clang_getCursorResultType(self.x),
-            };
-            if true { Some(ret) } else { None }
-        }
-    }
-
-    /// Given that this cursor's referent is a function/method call or
     /// declaration, return the number of arguments it takes.
     ///
     /// Returns -1 if the cursor's referent is not a function/method call or


### PR DESCRIPTION
Well apparently nobody is using  `Cursor::ret_type` 😢 