### PR TITLE
clang::Cursor::definition should return Option<clang::Cursor>

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -249,11 +249,13 @@ impl Cursor {
     /// Given that this cursor's referent is a reference to another type, or is
     /// a declaration, get the cursor pointing to the referenced type or type of
     /// the declared thing.
-    pub fn definition(&self) -> Cursor {
+    pub fn definition(&self) -> Option<Cursor> {
         unsafe {
-            Cursor {
+            let ret = Cursor {
                 x: clang_getCursorDefinition(self.x),
-            }
+            };
+
+            if ret.is_valid() { Some(ret) } else { None }
         }
     }
 

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -801,12 +801,7 @@ impl ClangItemParser for Item {
         // Types are sort of special, so to avoid parsing template classes
         // twice, handle them separately.
         {
-            let definition = cursor.definition();
-            let applicable_cursor = if definition.is_valid() {
-                definition
-            } else {
-                cursor
-            };
+            let applicable_cursor = cursor.definition().unwrap_or(cursor);
             match Self::from_ty(&applicable_cursor.cur_type(),
                                 Some(applicable_cursor),
                                 parent_id,
@@ -937,12 +932,7 @@ impl ClangItemParser for Item {
 
         let decl = {
             let decl = ty.declaration();
-            let definition = decl.definition();
-            if definition.is_valid() {
-                definition
-            } else {
-                decl
-            }
+            decl.definition().unwrap_or(decl)
         };
 
         let comment = decl.raw_comment()


### PR DESCRIPTION
Fixes #123

Paired with @glasserc