### PR TITLE
Don't be loud about ignoring macro expansion cursors

### DIFF
--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -822,6 +822,8 @@ impl ClangItemParser for Item {
             match cursor.kind() {
                 CXCursor_MacroDefinition |
                 CXCursor_MacroExpansion |
+                CXCursor_UsingDeclaration |
+                CXCursor_StaticAssert |
                 CXCursor_InclusionDirective => {
                     debug!("Unhandled cursor kind {:?}: {:?}",
                            cursor.kind(),

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -821,6 +821,7 @@ impl ClangItemParser for Item {
             // too noisy about this.
             match cursor.kind() {
                 CXCursor_MacroDefinition |
+                CXCursor_MacroExpansion |
                 CXCursor_InclusionDirective => {
                     debug!("Unhandled cursor kind {:?}: {:?}",
                            cursor.kind(),


### PR DESCRIPTION
r? @emilio 

We walk the expanded code already. These cursors are children of the translation unit for some reason, and let you iterate over tokens from before the macro was expanded. Pretty safe to ignore here.