### PR TITLE
Rework CI and add macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,39 @@
 language: rust
+
 addons:
-    apt:
-      sources:
-        - llvm-toolchain-precise-3.8
-        - ubuntu-toolchain-r-test
-      packages:
-        - libclang-3.8-dev
-        - llvm-3.8-dev
-env:
-  - LLVM_VERSION=3.8
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-5
+
+os:
+  - linux
+  - osx
+
 rust:
   - stable
   - nightly
+
+env:
+  - LLVM_VERSION=3.8 BINDGEN_FEATURES=llvm_stable
+  - LLVM_VERSION=3.9 BINDGEN_FEATURES=
+
 cache:
   directories:
     - $HOME/.cargo
 
-before_install:
-  -
-    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      if [ "${LLVM_VERSION}" != "devtools" ]; then
-        brew update >/dev/null;
-        brew install llvm3${LLVM_VERSION#3.};
-      fi
-    fi
-
-before_script:
-  -
-    if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-      export LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib;
-    elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      if [ "${LLVM_VERSION}" = "devtools" ]; then
-        export LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib;
-      else
-        export LIBCLANG_PATH=`brew --prefix llvm3${LLVM_VERSION#3.}`/lib/llvm-${LLVM_VERSION}/lib;
-      fi
-    fi
-  - echo $LIBCLANG_PATH
+before_install: . ./ci/before_install.sh
 
 script:
-  - cargo build --verbose --features llvm_stable
-  - cargo test --features llvm_stable
-  - cargo build --release --verbose --features llvm_stable
-  - cargo test --release --features llvm_stable
+  - cargo build --verbose --features "$BINDGEN_FEATURES"
+  - cargo test --features "$BINDGEN_FEATURES"
+  - cargo build --release --verbose --features "$BINDGEN_FEATURES"
+  - cargo test --release --features "$BINDGEN_FEATURES"
   - git add -A
   - git diff @
   - git diff-index --quiet HEAD
-  - cargo build --features "llvm_stable _docs"
+  - cargo build --features "$BINDGEN_FEATURES _docs"
 
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,0 +1,39 @@
+set -e
+pushd ~
+
+# Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+    rvm get head || true
+fi
+
+function llvm_version_triple() {
+    if [ "$1" == "3.8" ]; then
+        echo "3.8.0"
+    elif [ "$1" == "3.9" ]; then
+        echo "3.9.0"
+    fi
+}
+
+function llvm_download() {
+    export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
+    export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-x86_64-$1
+
+    wget http://llvm.org/releases/${LLVM_VERSION_TRIPLE}/${LLVM}.tar.xz
+    mkdir llvm
+    tar -xf ${LLVM}.tar.xz -C llvm --strip-components=1
+
+    export LLVM_CONFIG_PATH=`pwd`/llvm/bin/llvm-config
+    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+        cp llvm/lib/libclang.dylib /usr/local/lib/libclang.dylib
+    fi
+}
+
+
+if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    llvm_download linux-gnu-ubuntu-14.04
+else
+    llvm_download apple-darwin
+fi
+
+popd
+set +e


### PR DESCRIPTION
Adds 3.9 builds and macOS builds.

Clang is installed from llvm.org instead of installed from `apt-get`/`brew` (this is significantly faster, especially on macOS because brew is really slow).