### PR TITLE
Wrap enum_val_signed in an Option.

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -349,11 +349,15 @@ impl Cursor {
 
     /// Get the signed constant value for this cursor's enum variant referent.
     ///
-    /// Returns `LLONG_MIN` if the cursor's referent is not an enum variant,
-    /// which is also a valid enum value, so callers should check the cursor
-    /// kind before calling this method (see issue #127).
-    pub fn enum_val_signed(&self) -> i64 {
-        unsafe { clang_getEnumConstantDeclValue(self.x) as i64 }
+    /// Returns None if the cursor's referent is not an enum variant.
+    pub fn enum_val_signed(&self) -> Option<i64> {
+        unsafe {
+            if self.kind() == CXCursor_EnumConstantDecl {
+                Some(clang_getEnumConstantDeclValue(self.x) as i64)
+            } else {
+                None
+            }
+        }
     }
 
     /// Get the unsigned constant value for this cursor's enum variant referent.

--- a/src/ir/enum_ty.rs
+++ b/src/ir/enum_ty.rs
@@ -71,14 +71,18 @@ impl Enum {
         };
 
         declaration.visit(|cursor| {
-            if cursor.kind() == CXCursor_EnumConstantDecl {
+            let val = if is_signed {
+                cursor.enum_val_signed().map(EnumVariantValue::Signed)
+            } else {
+                if cursor.kind() == CXCursor_EnumConstantDecl {
+                    Some(EnumVariantValue::Unsigned(cursor.enum_val_unsigned()))
+                } else {
+                    None
+                }
+            };
+            if let Some(val) = val {
                 let name = cursor.spelling();
                 let comment = cursor.raw_comment();
-                let val = if is_signed {
-                    EnumVariantValue::Signed(cursor.enum_val_signed())
-                } else {
-                    EnumVariantValue::Unsigned(cursor.enum_val_unsigned())
-                };
                 variants.push(EnumVariant::new(name, comment, val));
             }
             CXChildVisit_Continue

--- a/src/ir/enum_ty.rs
+++ b/src/ir/enum_ty.rs
@@ -71,23 +71,20 @@ impl Enum {
         };
 
         declaration.visit(|cursor| {
-            let val = if is_signed {
-                cursor.enum_val_signed().map(EnumVariantValue::Signed)
-            } else {
-                if cursor.kind() == CXCursor_EnumConstantDecl {
-                    Some(EnumVariantValue::Unsigned(cursor.enum_val_unsigned()))
+            if cursor.kind() == CXCursor_EnumConstantDecl {
+                let value = if is_signed {
+                    cursor.enum_val_signed().map(EnumVariantValue::Signed)
                 } else {
-                    None
+                    Some(EnumVariantValue::Unsigned(cursor.enum_val_unsigned()))
+                };
+                if let Some(val) = value {
+                    let name = cursor.spelling();
+                    let comment = cursor.raw_comment();
+                    variants.push(EnumVariant::new(name, comment, val));
                 }
-            };
-            if let Some(val) = val {
-                let name = cursor.spelling();
-                let comment = cursor.raw_comment();
-                variants.push(EnumVariant::new(name, comment, val));
             }
             CXChildVisit_Continue
         });
-
         Ok(Enum::new(repr, variants))
     }
 }


### PR DESCRIPTION
Also reorganize calling code to avoid duplicate checking of cursor type.

Fixes #127