### PR TITLE
Add `clang::Type::is_valid` and use it instead of checking self.kind() against CXType_Invalid

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -715,6 +715,11 @@ impl Type {
             }
         }
     }
+
+    /// Is this a valid type?
+    pub fn is_valid(&self) -> bool {
+        self.kind() != CXType_Invalid
+    }
 }
 
 /// An iterator for a type's template arguments.

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -640,7 +640,7 @@ impl Type {
                 let ret = Type {
                     x: unsafe { clang_getPointeeType(self.x) },
                 };
-                debug_assert!(ret.kind() != CXType_Invalid);
+                debug_assert!(ret.is_valid());
                 Some(ret)
             }
             _ => None,
@@ -653,7 +653,7 @@ impl Type {
         let current_type = Type {
             x: unsafe { clang_getElementType(self.x) },
         };
-        if current_type.kind() != CXType_Invalid {
+        if current_type.is_valid() {
             Some(current_type)
         } else {
             None
@@ -692,10 +692,10 @@ impl Type {
         let rt = Type {
             x: unsafe { clang_getResultType(self.x) },
         };
-        if rt.kind() == CXType_Invalid {
-            None
-        } else {
+        if rt.is_valid() {
             Some(rt)
+        } else {
+            None
         }
     }
 

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -331,6 +331,12 @@ impl Item {
         self.kind().expect_type()
     }
 
+    /// Get a reference to this item's underlying `Type`, or `None` if this is
+    /// some other kind of item.
+    pub fn as_type(&self) -> Option<&Type> {
+        self.kind().as_type()
+    }
+
     /// Get a reference to this item's underlying `Function`. Panic if this is
     /// some other kind of item.
     pub fn expect_function(&self) -> &Function {
@@ -529,6 +535,11 @@ impl Item {
                       "You're not supposed to call this yet");
         self.annotations.opaque() ||
         ctx.opaque_by_name(&self.real_canonical_name(ctx, false, true))
+    }
+
+    /// Is this a reference to another type?
+    pub fn is_type_ref(&self) -> bool {
+        self.as_type().map_or(false, |ty| ty.is_type_ref())
     }
 
     /// Get the canonical name without taking into account the replaces

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -136,6 +136,15 @@ impl Type {
         self.is_const
     }
 
+    /// Is this a reference to another type?
+    pub fn is_type_ref(&self) -> bool {
+        match self.kind {
+            TypeKind::ResolvedTypeRef(_) |
+            TypeKind::UnresolvedTypeRef(_, _, _) => true,
+            _ => false,
+        }
+    }
+
     /// What is the layout of this type?
     pub fn layout(&self, ctx: &BindgenContext) -> Option<Layout> {
         use std::mem;


### PR DESCRIPTION
Needed `is_valid()` when debugging, so figured we should land this and update places where we compare against the magical sentinel value.

r? @emilio 