### PR TITLE
clang::Cursor::referenced should return Option<clang::Cursor>

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -263,11 +263,13 @@ impl Cursor {
 
     /// Given that this cursor's referent is reference type, get the cursor
     /// pointing to the referenced type.
-    pub fn referenced(&self) -> Cursor {
+    pub fn referenced(&self) -> Option<Cursor>  {
         unsafe {
-            Cursor {
+            let ret = Cursor {
                 x: clang_getCursorReferenced(self.x),
-            }
+            };
+
+            if ret.is_valid() { Some(ret) } else { None }
         }
     }
 

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -612,7 +612,7 @@ impl Type {
                             TypeKind::TemplateAlias(inner.unwrap(), args)
                         }
                         CXCursor_TemplateRef => {
-                            let referenced = location.referenced();
+                            let referenced = location.referenced().expect("expected value, got none");
                             let referenced_ty = referenced.cur_type();
                             let referenced_declaration =
                                 Some(referenced_ty.declaration());
@@ -624,7 +624,7 @@ impl Type {
                                                        ctx);
                         }
                         CXCursor_TypeRef => {
-                            let referenced = location.referenced();
+                            let referenced = location.referenced().expect("expected value, got none");
                             let referenced_ty = referenced.cur_type();
                             let referenced_declaration =
                                 Some(referenced_ty.declaration());


### PR DESCRIPTION
Fixes https://github.com/servo/rust-bindgen/issues/124
Since I am new to Rust, I hope I didn't do things too badly
