### PR TITLE
Disable OSX builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 
 os:
   - linux
-  - osx
 
 rust:
   - stable

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,11 +1,6 @@
 set -e
 pushd ~
 
-# Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)
-if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-    rvm get head || true
-fi
-
 function llvm_version_triple() {
     if [ "$1" == "3.8" ]; then
         echo "3.8.0"
@@ -23,17 +18,9 @@ function llvm_download() {
     tar -xf ${LLVM}.tar.xz -C llvm --strip-components=1
 
     export LLVM_CONFIG_PATH=`pwd`/llvm/bin/llvm-config
-    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-        cp llvm/lib/libclang.dylib /usr/local/lib/libclang.dylib
-    fi
 }
 
-
-if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-    llvm_download linux-gnu-ubuntu-14.04
-else
-    llvm_download apple-darwin
-fi
+llvm_download linux-gnu-ubuntu-14.04
 
 popd
 set +e


### PR DESCRIPTION
The wait time to get OSX machines on Travis CI is *way* too long at the
moment. We'll be able to revert this commit in the future, once Travis
CI adds more OSX machines to their cluster, hopefully.

r? @emilio 