### PR TITLE
codegen: Special-case i64::MIN since it produces a overflow on aster.

### DIFF
--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -117,4 +117,19 @@ pub mod ast_ty {
             }
         }
     }
+
+    pub fn int_expr(val: i64) -> P<ast::Expr> {
+        use std::i64;
+        let expr = aster::AstBuilder::new().expr();
+
+        // This is not representable as an i64 if it's negative, so we
+        // special-case it.
+        //
+        // Fix in aster incoming.
+        if val == i64::MIN {
+            expr.neg().uint(1u64 << 63)
+        } else {
+            expr.int(val)
+        }
+    }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -101,7 +101,8 @@ impl CodegenResult {
     /// counter internally so the next time we ask for the overload for this
     /// name, we get the incremented value, and so on.
     fn overload_number(&mut self, name: &str) -> u32 {
-        let mut counter = self.overload_counters.entry(name.into()).or_insert(0);
+        let mut counter =
+            self.overload_counters.entry(name.into()).or_insert(0);
         let number = *counter;
         *counter += 1;
         number
@@ -313,7 +314,7 @@ impl CodeGenerator for Var {
                 .pub_()
                 .const_(canonical_name)
                 .expr()
-                .int(val)
+                .build(helpers::ast_ty::int_expr(val))
                 .build(ty);
             result.push(const_item)
         } else {
@@ -1285,7 +1286,7 @@ impl<'a> EnumBuilder<'a> {
         let variant_name = ctx.rust_mangle(variant.name());
         let expr = aster::AstBuilder::new().expr();
         let expr = match variant.val() {
-            EnumVariantValue::Signed(v) => expr.int(v),
+            EnumVariantValue::Signed(v) => helpers::ast_ty::int_expr(v),
             EnumVariantValue::Unsigned(v) => expr.uint(v),
         };
 

--- a/tests/expectations/tests/enum_explicit_type.rs
+++ b/tests/expectations/tests/enum_explicit_type.rs
@@ -16,6 +16,9 @@ pub enum Bigger { Much = 255, Larger = 256, }
 #[repr(i64)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MuchLong { MuchLow = -4294967296, }
+#[repr(i64)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum MuchLongLong { I64_MIN = -9223372036854775808, }
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MuchLongLong { MuchHigh = 4294967296, }
+pub enum MuchULongLong { MuchHigh = 4294967296, }

--- a/tests/expectations/tests/macro-expr-basic.rs
+++ b/tests/expectations/tests/macro-expr-basic.rs
@@ -7,6 +7,7 @@
 pub const FOO: ::std::os::raw::c_uint = 1;
 pub const BAR: ::std::os::raw::c_uint = 4;
 pub const BAZ: ::std::os::raw::c_uint = 5;
+pub const MIN: ::std::os::raw::c_longlong = -9223372036854775808;
 pub const BARR: ::std::os::raw::c_uint = 1;
 pub const BAZZ: ::std::os::raw::c_uint = 7;
 pub const I_RAN_OUT_OF_DUMB_NAMES: ::std::os::raw::c_uint = 7;

--- a/tests/headers/enum_explicit_type.hpp
+++ b/tests/headers/enum_explicit_type.hpp
@@ -19,6 +19,10 @@ enum MuchLong: long {
     MuchLow = -4294967296,
 };
 
-enum MuchLongLong: unsigned long long {
+enum MuchLongLong: long long {
+    I64_MIN = 1ll << 63,
+};
+
+enum MuchULongLong: unsigned long long {
     MuchHigh = 4294967296,
 };

--- a/tests/headers/macro-expr-basic.h
+++ b/tests/headers/macro-expr-basic.h
@@ -2,6 +2,8 @@
 #define BAR 4
 #define BAZ (FOO + BAR)
 
+#define MIN (1 << 63)
+
 #define BARR (1 << 0)
 #define BAZZ ((1 << 1) + BAZ)
 #define I_RAN_OUT_OF_DUMB_NAMES (BARR | BAZZ)


### PR DESCRIPTION
Proper fix on aster soon, still worth to get this in I guess.

r? @fitzgen