### PR TITLE
Clean up TypeCollector implementations

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -846,24 +846,24 @@ impl TypeCollector for CompInfo {
                      types: &mut ItemSet,
                      item: &Item) {
         if let Some(template) = self.specialized_template() {
-            template.collect_types(context, types, &());
+            types.insert(template);
         }
 
         let applicable_template_args = item.applicable_template_args(context);
         for arg in applicable_template_args {
-            arg.collect_types(context, types, &());
+            types.insert(arg);
         }
 
-        for base in self.base_members() {
-            base.collect_types(context, types, &());
+        for &base in self.base_members() {
+            types.insert(base);
         }
 
         for field in self.fields() {
-            field.ty().collect_types(context, types, &());
+            types.insert(field.ty());
         }
 
-        for ty in self.inner_types() {
-            ty.collect_types(context, types, &());
+        for &ty in self.inner_types() {
+            types.insert(ty);
         }
 
         // FIXME(emilio): Methods, VTable?

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -270,13 +270,13 @@ impl TypeCollector for FunctionSig {
     type Extra = Item;
 
     fn collect_types(&self,
-                     context: &BindgenContext,
+                     _context: &BindgenContext,
                      types: &mut ItemSet,
                      _item: &Item) {
-        self.return_type().collect_types(context, types, &());
+        types.insert(self.return_type());
 
         for &(_, ty) in self.argument_types() {
-            ty.collect_types(context, types, &());
+            types.insert(ty);
         }
     }
 }

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -153,7 +153,6 @@ impl TypeCollector for Item {
 
         match *self.kind() {
             ItemKind::Type(ref ty) => {
-                types.insert(self.id());
                 if !self.is_opaque(ctx) {
                     ty.collect_types(ctx, types, self);
                 }

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -847,13 +847,13 @@ impl TypeCollector for Type {
             TypeKind::Alias(_, inner) |
             TypeKind::Named(_, Some(inner)) |
             TypeKind::ResolvedTypeRef(inner) => {
-                inner.collect_types(context, types, &())
+                types.insert(inner);
             }
 
             TypeKind::TemplateRef(inner, ref template_args) => {
-                inner.collect_types(context, types, &());
-                for item in template_args {
-                    item.collect_types(context, types, &());
+                types.insert(inner);
+                for &item in template_args {
+                    types.insert(item);
                 }
             }
             TypeKind::Comp(ref ci) => ci.collect_types(context, types, item),
@@ -862,7 +862,7 @@ impl TypeCollector for Type {
             }
             // FIXME: Pending types!
             ref other @ _ => {
-                debug!("Ignoring: {:?}", other);
+                debug!("<Type as TypeCollector>::collect_types: Ignoring: {:?}", other);
             }
         }
     }


### PR DESCRIPTION
Rather than making `TypeCollector` implementations recursively call
`collect_types` on their subtypes, just gather immediate subtypes into
the `ItemSet`. The subtypes' `TypeCollector` implementation will be
recursively called by `WhitelistedItemsIter`. This makes it less likely
we will "skip" a layer by recursively calling `collect_types` on
some subtypes without adding the subtypes themselves to the set.

r? @emilio 