### PR TITLE
Warn when giving up and assuming a named type

### DIFF
--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1051,6 +1051,9 @@ impl ClangItemParser for Item {
                 // It's harmless, but if we restrict that, then
                 // tests/headers/nsStyleAutoArray.hpp crashes.
                 if let Err(ParseError::Recurse) = result {
+                    warn!("Unknown type, assuming named template type: id = {:?}; spelling = {}",
+                          id,
+                          ty.spelling());
                     Ok(Self::named_type_with_id(id,
                                                 ty.spelling(),
                                                 None,


### PR DESCRIPTION
When we fail to parse Clang stuff into our IR and give up, and assume
that we are looking at a named template type, we now emit a warning to
assist with debugging.

r? @emilio 