### PR TITLE
Add an option to emit our ir for debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ os:
 
 rust:
   - stable
-  - nightly
 
 env:
   - LLVM_VERSION=3.8 BINDGEN_FEATURES=llvm_stable

--- a/libbindgen/src/codegen/mod.rs
+++ b/libbindgen/src/codegen/mod.rs
@@ -1892,6 +1892,13 @@ pub fn codegen(context: &mut BindgenContext) -> Vec<P<ast::Item>> {
 
         let whitelisted_items: ItemSet = context.whitelisted_items().collect();
 
+        if context.options().emit_ir {
+            for &id in whitelisted_items.iter() {
+                let item = context.resolve_item(id);
+                println!("ir: {:?} = {:#?}", id, item);
+            }
+        }
+
         for &id in whitelisted_items.iter() {
             let item = context.resolve_item(id);
 

--- a/libbindgen/src/lib.rs
+++ b/libbindgen/src/lib.rs
@@ -225,6 +225,12 @@ impl Builder {
         self
     }
 
+    /// Emit IR.
+    pub fn emit_ir(mut self) -> Builder {
+        self.options.emit_ir = true;
+        self
+    }
+
     /// Enable C++ namespaces.
     pub fn enable_cxx_namespaces(mut self) -> Builder {
         self.options.enable_cxx_namespaces = true;
@@ -314,6 +320,9 @@ pub struct BindgenOptions {
     /// True if we should dump the Clang AST for debugging purposes.
     pub emit_ast: bool,
 
+    /// True if we should dump our internal IR for debugging purposes.
+    pub emit_ir: bool,
+
     /// True if we should ignore functions and only generate bindings for
     /// structures, types, and methods.
     pub ignore_functions: bool,
@@ -380,6 +389,7 @@ impl Default for BindgenOptions {
             builtins: false,
             links: vec![],
             emit_ast: false,
+            emit_ir: false,
             ignore_functions: false,
             ignore_methods: false,
             derive_debug: true,

--- a/src/options.rs
+++ b/src/options.rs
@@ -52,6 +52,9 @@ pub fn builder_from_flags<I>(args: I)
             Arg::with_name("emit-clang-ast")
                 .long("emit-clang-ast")
                 .help("Output the Clang AST for debugging purposes."),
+            Arg::with_name("emit-ir")
+                .long("emit-ir")
+                .help("Output our internal IR for debugging purposes."),
             Arg::with_name("enable-cxx-namespaces")
                 .long("enable-cxx-namespaces")
                 .help("Enable support for C++ namespaces."),
@@ -181,6 +184,10 @@ pub fn builder_from_flags<I>(args: I)
 
     if matches.is_present("emit-clang-ast") {
         builder = builder.emit_clang_ast();
+    }
+
+    if matches.is_present("emit-ir") {
+        builder = builder.emit_ir();
     }
 
     if matches.is_present("enable-cxx-namespaces") {


### PR DESCRIPTION
Similar to our ability to emit the clang AST, this adds an option to
emit our IR for debugging purposes.

This can wait to land until after #204 is merged.

r? @emilio 