### PR TITLE
libbindgen: Make logging optional

### DIFF
--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -28,8 +28,6 @@ cfg-if = "0.1.0"
 clang-sys = "0.8.0"
 lazy_static = "0.1.*"
 libc = "0.2"
-log = "0.3"
-env_logger = "0.3"
 rustc-serialize = "0.3.19"
 syntex_syntax = "0.44"
 regex = "0.1"
@@ -43,12 +41,22 @@ version = "0.28"
 optional = true
 version = "*"
 
+[dependencies.env_logger]
+optional = true
+version = "0.3"
+
+[dependencies.log]
+optional = true
+version = "0.3"
+
 [dependencies.quasi]
 features = ["with-syntex"]
 version = "0.20"
 
 [features]
+default = ["logging"]
 llvm_stable = []
+logging = ["env_logger", "log"]
 static = []
 # This feature only exists for CI -- don't use it!
 _docs = []

--- a/libbindgen/src/lib.rs
+++ b/libbindgen/src/lib.rs
@@ -29,9 +29,15 @@ extern crate clang_sys;
 extern crate libc;
 extern crate regex;
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate lazy_static;
+
+#[cfg(feature = "logging")]
+#[macro_use]
+extern crate log;
+
+#[cfg(not(feature = "logging"))]
+#[macro_use]
+mod log_stubs;
 
 // A macro to declare an internal module for which we *must* provide
 // documentation for. If we are building with the "_docs" feature, then the

--- a/libbindgen/src/log_stubs.rs
+++ b/libbindgen/src/log_stubs.rs
@@ -1,0 +1,30 @@
+macro_rules! log {
+    (target: $target:expr, $lvl:expr, $($arg)+) => {
+        let _ = $target;
+        let _ = log!($lvl, $($arg)+);
+    };
+    ($lvl:expr, $($arg:tt)+) => {
+        let _ = $lvl;
+        let _ = format_args!($($arg)+);
+    };
+}
+macro_rules! error {
+    (target: $target:expr, $($arg:tt)*) => { log!($target, $($arg)*); };
+    ($($arg:tt)*) => { log!("", $($arg)*); };
+}
+macro_rules! warn {
+    (target: $target:expr, $($arg:tt)*) => { log!($target, $($arg)*); };
+    ($($arg:tt)*) => { log!("", $($arg)*); };
+}
+macro_rules! info {
+    (target: $target:expr, $($arg:tt)*) => { log!($target, $($arg)*); };
+    ($($arg:tt)*) => { log!("", $($arg)*); };
+}
+macro_rules! debug {
+    (target: $target:expr, $($arg:tt)*) => { log!($target, $($arg)*); };
+    ($($arg:tt)*) => { log!("", $($arg)*); };
+}
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)*) => { log!($target, $($arg)*); };
+    ($($arg:tt)*) => { log!("", $($arg)*); };
+}

--- a/libbindgen/tests/tests.rs
+++ b/libbindgen/tests/tests.rs
@@ -1,9 +1,6 @@
 extern crate clap;
 extern crate diff;
-#[macro_use]
-extern crate env_logger;
 extern crate libbindgen;
-extern crate log;
 extern crate shlex;
 
 use std::fs;


### PR DESCRIPTION
Note that the log crate isn't completely banished, as other is required by other dependencies.

Believe it or not, this change was the original aim of #204.