### PR TITLE
Make syntex optional with nightly rustc

### DIFF
--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -20,22 +20,20 @@ clap = "2"
 shlex = "0.1"
 tests_expectations = { path = "tests/expectations" }
 
-[build-dependencies]
-quasi_codegen = "0.21"
+[build-dependencies.quasi_codegen]
+default-features = false
+version = "0.25"
 
 [dependencies]
+aster = "0.33"
+cexpr = "0.2"
 cfg-if = "0.1.0"
 clang-sys = "0.8.0"
 lazy_static = "0.1.*"
 libc = "0.2"
-rustc-serialize = "0.3.19"
-syntex_syntax = "0.44"
+quasi = "0.25"
 regex = "0.1"
-cexpr = "0.2"
-
-[dependencies.aster]
-features = ["with-syntex"]
-version = "0.29"
+rustc-serialize = "0.3.19"
 
 [dependencies.clippy]
 optional = true
@@ -49,14 +47,15 @@ version = "0.3"
 optional = true
 version = "0.3"
 
-[dependencies.quasi]
-features = ["with-syntex"]
-version = "0.21"
+[dependencies.syntex_syntax]
+optional = true
+version = "0.48"
 
 [features]
-default = ["logging"]
+default = ["logging", "syntex"]
 llvm_stable = []
 logging = ["env_logger", "log"]
 static = []
+syntex = ["syntex_syntax", "aster/with-syntex", "quasi/with-syntex", "quasi_codegen/with-syntex"]
 # This feature only exists for CI -- don't use it!
 _docs = []

--- a/libbindgen/src/ir/context.rs
+++ b/libbindgen/src/ir/context.rs
@@ -397,7 +397,7 @@ impl<'ctx> BindgenContext<'ctx> {
         let sess = parse::ParseSess::new();
         let mut loader = base::DummyResolver;
         let mut ctx =
-            GenContext(base::ExtCtxt::new(&sess, vec![], cfg, &mut loader));
+            GenContext(base::ExtCtxt::new(&sess, cfg, &mut loader));
 
         ctx.0.bt_push(ExpnInfo {
             call_site: self.span,

--- a/libbindgen/src/lib.rs
+++ b/libbindgen/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+#![cfg_attr(not(feature = "syntex"), feature(rustc_private))]
+
 #![deny(missing_docs)]
 #![deny(warnings)]
 
@@ -22,7 +24,6 @@
 #[macro_use]
 extern crate cfg_if;
 extern crate cexpr;
-extern crate syntex_syntax as syntax;
 extern crate aster;
 extern crate quasi;
 extern crate clang_sys;
@@ -38,6 +39,12 @@ extern crate log;
 #[cfg(not(feature = "logging"))]
 #[macro_use]
 mod log_stubs;
+
+#[cfg(feature = "syntex")]
+extern crate syntex_syntax as syntax;
+
+#[cfg(not(feature = "syntex"))]
+extern crate syntax;
 
 // A macro to declare an internal module for which we *must* provide
 // documentation for. If we are building with the "_docs" feature, then the


### PR DESCRIPTION
The start of a change, suggested by @emilio, that will allow users of nightly rustc to drop syntex. It doesn't currently build -- probably requires aster and quasi updates. That might get hairy, so consider this a work in progress and a proposal that can be quickly refused if it's totally off base.

This depends on #269 so currently includes those commits.