### PR TITLE
Update quasi to 0.21

### DIFF
--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -21,7 +21,7 @@ shlex = "0.1"
 tests_expectations = { path = "tests/expectations" }
 
 [build-dependencies]
-quasi_codegen = "0.20"
+quasi_codegen = "0.21"
 
 [dependencies]
 cfg-if = "0.1.0"
@@ -35,7 +35,7 @@ cexpr = "0.2"
 
 [dependencies.aster]
 features = ["with-syntex"]
-version = "0.28"
+version = "0.29"
 
 [dependencies.clippy]
 optional = true
@@ -51,7 +51,7 @@ version = "0.3"
 
 [dependencies.quasi]
 features = ["with-syntex"]
-version = "0.20"
+version = "0.21"
 
 [features]
 default = ["logging"]


### PR DESCRIPTION
This is not the latest version, because the latest version doesn't work
due to serde-rs/quasi#65.

The issue of keeping using 0.20 is that libbindgen depends on aster 0.28
while quasi depends on aster 0.27, which leads to duplicate versions of
aster dependency. Updating quasi to 0.21 brings aster to 0.29, which
also works for libbindgen.