### PR TITLE
ir: Avoid generating out-of-range values in constants.

### DIFF
--- a/libbindgen/src/codegen/mod.rs
+++ b/libbindgen/src/codegen/mod.rs
@@ -228,7 +228,8 @@ impl CodeGenerator for Item {
                result: &mut CodegenResult,
                _extra: &()) {
         if self.is_hidden(ctx) || result.seen(self.id()) {
-            debug!("<Item as CodeGenerator>::codegen: Ignoring hidden or seen: self = {:?}", self);
+            debug!("<Item as CodeGenerator>::codegen: Ignoring hidden or seen: \
+                   self = {:?}", self);
             return;
         }
 
@@ -328,8 +329,7 @@ impl CodeGenerator for Var {
                         .build(ty)
                 }
                 VarType::Int(val) => {
-                    const_item.build(helpers::ast_ty::int_expr(val))
-                        .build(ty)
+                    const_item.build(helpers::ast_ty::int_expr(val)).build(ty)
                 }
                 VarType::String(ref bytes) => {
                     // Account the trailing zero.

--- a/libbindgen/src/ir/int.rs
+++ b/libbindgen/src/ir/int.rs
@@ -90,4 +90,9 @@ impl IntKind {
             Custom { is_signed, .. } => is_signed,
         }
     }
+
+    /// Whether this type's signedness matches the value.
+    pub fn signedness_matches(&self, val: i64) -> bool {
+        val >= 0 || self.is_signed()
+    }
 }

--- a/libbindgen/src/ir/item.rs
+++ b/libbindgen/src/ir/item.rs
@@ -1032,7 +1032,8 @@ impl ClangItemParser for Item {
                 // It's harmless, but if we restrict that, then
                 // tests/headers/nsStyleAutoArray.hpp crashes.
                 if let Err(ParseError::Recurse) = result {
-                    warn!("Unknown type, assuming named template type: id = {:?}; spelling = {}",
+                    warn!("Unknown type, assuming named template type: \
+                          id = {:?}; spelling = {}",
                           id,
                           ty.spelling());
                     Ok(Self::named_type_with_id(id,

--- a/libbindgen/src/ir/ty.rs
+++ b/libbindgen/src/ir/ty.rs
@@ -878,7 +878,9 @@ impl TypeCollector for Type {
             }
             // FIXME: Pending types!
             ref other @ _ => {
-                debug!("<Type as TypeCollector>::collect_types: Ignoring: {:?}", other);
+                debug!("<Type as TypeCollector>::collect_types: Ignoring: \
+                       {:?}",
+                       other);
             }
         }
     }

--- a/libbindgen/tests/expectations/tests/constant-evaluate.rs
+++ b/libbindgen/tests/expectations/tests/constant-evaluate.rs
@@ -9,6 +9,9 @@ pub const bar: _bindgen_ty_1 = _bindgen_ty_1::bar;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum _bindgen_ty_1 { foo = 4, bar = 8, }
+pub type EasyToOverflow = ::std::os::raw::c_ulonglong;
+pub const k: EasyToOverflow = 2147483648;
+pub const k_expr: EasyToOverflow = 0;
 pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.;
 pub const BAZZ: ::std::os::raw::c_char = 53;

--- a/libbindgen/tests/headers/constant-evaluate.h
+++ b/libbindgen/tests/headers/constant-evaluate.h
@@ -5,6 +5,11 @@ enum {
   bar = 8,
 };
 
+typedef unsigned long long EasyToOverflow;
+const EasyToOverflow k = 0x80000000;
+
+const EasyToOverflow k_expr = 1ULL << 60;
+
 const long long BAZ = (1 << foo) | bar;
 const double fuzz = (1 + 50.0f);
 const char BAZZ = '5';


### PR DESCRIPTION
Partially addresses #274 until my patch or a similar one gets accepted and we can use it.

r? @fitzgen or @upsuper