### PR TITLE
clang::Cursor::enum_type should return an Option<Type>

### DIFF
--- a/libbindgen/src/clang.rs
+++ b/libbindgen/src/clang.rs
@@ -367,7 +367,7 @@ impl Cursor {
             let t = Type {
                 x: clang_getEnumDeclIntegerType(self.x),
             };
-            if t.kind() == CXType_Invalid { None } else { Some(t) }
+            if t.is_valid() { Some(t) } else { None }
         }
     }
 

--- a/libbindgen/src/clang.rs
+++ b/libbindgen/src/clang.rs
@@ -362,11 +362,12 @@ impl Cursor {
 
     /// Get the integer representation type used to hold this cursor's referent
     /// enum type.
-    pub fn enum_type(&self) -> Type {
+    pub fn enum_type(&self) -> Option<Type> {
         unsafe {
-            Type {
+            let t = Type {
                 x: clang_getEnumDeclIntegerType(self.x),
-            }
+            };
+            if t.kind() == CXType_Invalid { None } else { Some(t) }
         }
     }
 

--- a/libbindgen/src/ir/enum_ty.rs
+++ b/libbindgen/src/ir/enum_ty.rs
@@ -49,8 +49,8 @@ impl Enum {
         }
 
         let declaration = ty.declaration().canonical();
-        let repr = Item::from_ty(&declaration.enum_type(), None, None, ctx)
-            .ok();
+        let et = &declaration.enum_type().expect("This should be an enum since we checked above!");
+        let repr = Item::from_ty(et, None, None, ctx).ok();
         let mut variants = vec![];
 
         let is_signed = match repr {

--- a/libbindgen/src/ir/enum_ty.rs
+++ b/libbindgen/src/ir/enum_ty.rs
@@ -49,7 +49,7 @@ impl Enum {
         }
 
         let declaration = ty.declaration().canonical();
-        let et = &declaration.enum_type().expect("This should be an enum since we checked above!");
+        let et = &declaration.enum_type().expect("Expected an enum type");
         let repr = Item::from_ty(et, None, None, ctx).ok();
         let mut variants = vec![];
 

--- a/libbindgen/src/ir/enum_ty.rs
+++ b/libbindgen/src/ir/enum_ty.rs
@@ -49,11 +49,9 @@ impl Enum {
         }
 
         let declaration = ty.declaration().canonical();
-        let et = declaration.enum_type();
-        if et.is_none() {
-            return Err(ParseError::Continue);
-        }
-        let repr = Item::from_ty(&et.unwrap(), None, None, ctx).ok();
+        let repr = declaration.enum_type().and_then(|et| {
+            Item::from_ty(&et, None, None, ctx).ok()
+        });
         let mut variants = vec![];
 
         let is_signed = match repr {

--- a/libbindgen/src/ir/enum_ty.rs
+++ b/libbindgen/src/ir/enum_ty.rs
@@ -49,8 +49,11 @@ impl Enum {
         }
 
         let declaration = ty.declaration().canonical();
-        let et = &declaration.enum_type().expect("Expected an enum type");
-        let repr = Item::from_ty(et, None, None, ctx).ok();
+        let et = declaration.enum_type();
+        if et.is_none() {
+            return Err(ParseError::Continue);
+        }
+        let repr = Item::from_ty(&et.unwrap(), None, None, ctx).ok();
         let mut variants = vec![];
 
         let is_signed = match repr {


### PR DESCRIPTION
Returning an Option<Type> relieves callers from having to check whether clang::Cursor::enum_type returns `CXType_Invalid`.

Fixes #125 
