### PR TITLE
Recurse on the inner type when finding a template alias name target

### DIFF
--- a/libbindgen/src/ir/item.rs
+++ b/libbindgen/src/ir/item.rs
@@ -556,10 +556,6 @@ impl Item {
                         TypeKind::TemplateAlias(inner, _)
                             if for_name_checking => {
                             item = ctx.resolve_item(inner);
-                            assert_eq!(item.id(),
-                                       item.name_target(ctx,
-                                                        for_name_checking));
-                            return item.id();
                         }
                         _ => return item.id(),
                     }


### PR DESCRIPTION
The assertion that the template alias's inner type was our name target,
and that we didn't need to recurse, is failing when generating
SpiderMonkey bindings. I'm not 100% sure when this can happen, but
clearly it can, and it is easy to support, so let's support it.

r? @emilio 