### PR TITLE
Use the generated root module via a relative path

### DIFF
--- a/libbindgen/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/libbindgen/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -6,10 +6,10 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     pub mod foo {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         #[repr(C)]
         #[derive(Debug, Copy)]
         pub struct Bar {
@@ -27,7 +27,7 @@ pub mod root {
     }
     pub mod bar {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         #[repr(C)]
         #[derive(Debug, Copy)]
         pub struct Foo {

--- a/libbindgen/tests/expectations/tests/duplicated-namespaces.rs
+++ b/libbindgen/tests/expectations/tests/duplicated-namespaces.rs
@@ -6,5 +6,5 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
 }

--- a/libbindgen/tests/expectations/tests/duplicated_constants_in_ns.rs
+++ b/libbindgen/tests/expectations/tests/duplicated_constants_in_ns.rs
@@ -6,15 +6,15 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     pub mod foo {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub const FOO: ::std::os::raw::c_int = 4;
     }
     pub mod bar {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub const FOO: ::std::os::raw::c_int = 5;
     }
 }

--- a/libbindgen/tests/expectations/tests/module-whitelisted.rs
+++ b/libbindgen/tests/expectations/tests/module-whitelisted.rs
@@ -6,7 +6,7 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct Test {

--- a/libbindgen/tests/expectations/tests/namespace.rs
+++ b/libbindgen/tests/expectations/tests/namespace.rs
@@ -6,14 +6,14 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     extern "C" {
         #[link_name = "_Z9top_levelv"]
         pub fn top_level();
     }
     pub mod whatever {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub type whatever_int_t = ::std::os::raw::c_int;
         extern "C" {
             #[link_name = "_ZN8whatever11in_whateverEv"]
@@ -22,7 +22,7 @@ pub mod root {
     }
     pub mod _bindgen_mod_id_13 {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         extern "C" {
             #[link_name = "_ZN12_GLOBAL__N_13fooEv"]
             pub fn foo();
@@ -51,7 +51,7 @@ pub mod root {
     }
     pub mod w {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub type whatever_int_t = ::std::os::raw::c_uint;
         #[repr(C)]
         #[derive(Debug)]

--- a/libbindgen/tests/expectations/tests/nested_within_namespace.rs
+++ b/libbindgen/tests/expectations/tests/nested_within_namespace.rs
@@ -6,10 +6,10 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     pub mod foo {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         #[repr(C)]
         #[derive(Debug, Copy)]
         pub struct Bar {

--- a/libbindgen/tests/expectations/tests/template_alias_namespace.rs
+++ b/libbindgen/tests/expectations/tests/template_alias_namespace.rs
@@ -6,13 +6,13 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     pub mod JS {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub mod detail {
             #[allow(unused_imports)]
-            use root;
+            use self::super::super::super::root;
             pub type Wrapped<T> = T;
         }
         #[repr(C)]

--- a/libbindgen/tests/expectations/tests/whitelist-namespaces-basic.rs
+++ b/libbindgen/tests/expectations/tests/whitelist-namespaces-basic.rs
@@ -6,13 +6,13 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     pub mod outer {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub mod inner {
             #[allow(unused_imports)]
-            use root;
+            use self::super::super::super::root;
             #[repr(C)]
             #[derive(Debug, Copy)]
             pub struct Helper {

--- a/libbindgen/tests/expectations/tests/whitelist-namespaces.rs
+++ b/libbindgen/tests/expectations/tests/whitelist-namespaces.rs
@@ -6,13 +6,13 @@
 
 pub mod root {
     #[allow(unused_imports)]
-    use root;
+    use self::super::root;
     pub mod outer {
         #[allow(unused_imports)]
-        use root;
+        use self::super::super::root;
         pub mod inner {
             #[allow(unused_imports)]
-            use root;
+            use self::super::super::super::root;
             #[repr(C)]
             #[derive(Debug, Copy)]
             pub struct Helper {


### PR DESCRIPTION
We previously generated uses of the root module with absolute paths:

    use root;

However this only works if the generated bindings are the root of the
crate. If they were in some submodule then that path would not be
valid. They are now generated relative to the current module, like this:

    use self::super::super::root;

Fixes #96

r? @emilio 