### PR TITLE
Assert that we won't infinite loop

### DIFF
--- a/libbindgen/src/ir/item.rs
+++ b/libbindgen/src/ir/item.rs
@@ -588,8 +588,13 @@ impl Item {
                    ctx: &BindgenContext,
                    for_name_checking: bool)
                    -> ItemId {
+        let mut targets_seen = AncestorsSeen::new();
         let mut item = self;
+
         loop {
+            debug_assert!(!targets_seen.contains(&item.id()));
+            targets_seen.insert(item.id());
+
             match *item.kind() {
                 ItemKind::Type(ref ty) => {
                     match *ty.kind() {

--- a/libbindgen/src/ir/item.rs
+++ b/libbindgen/src/ir/item.rs
@@ -57,13 +57,13 @@ pub trait ItemAncestors {
 
 cfg_if! {
     if #[cfg(debug_assertions)] {
-        type AncestorsSeen = ItemSet;
+        type DebugOnlyItemSet = ItemSet;
     } else {
-        struct AncestorsSeen;
+        struct DebugOnlyItemSet;
 
-        impl AncestorsSeen {
+        impl DebugOnlyItemSet {
             fn new() -> Self {
-                AncestorsSeen
+                DebugOnlyItemSet
             }
 
             fn contains(&self,_id: &ItemId) -> bool {
@@ -81,7 +81,7 @@ pub struct ItemAncestorsIter<'a, 'b>
 {
     item: ItemId,
     ctx: &'a BindgenContext<'b>,
-    seen: AncestorsSeen,
+    seen: DebugOnlyItemSet,
 }
 
 impl <'a, 'b> ItemAncestorsIter<'a, 'b>
@@ -91,7 +91,7 @@ impl <'a, 'b> ItemAncestorsIter<'a, 'b>
         ItemAncestorsIter {
             item: item,
             ctx: ctx,
-            seen: AncestorsSeen::new(),
+            seen: DebugOnlyItemSet::new(),
         }
     }
 }
@@ -588,7 +588,7 @@ impl Item {
                    ctx: &BindgenContext,
                    for_name_checking: bool)
                    -> ItemId {
-        let mut targets_seen = AncestorsSeen::new();
+        let mut targets_seen = DebugOnlyItemSet::new();
         let mut item = self;
 
         loop {

--- a/libbindgen/src/ir/item.rs
+++ b/libbindgen/src/ir/item.rs
@@ -55,12 +55,45 @@ pub trait ItemAncestors {
                          -> ItemAncestorsIter<'a, 'b>;
 }
 
+cfg_if! {
+    if #[cfg(debug_assertions)] {
+        type AncestorsSeen = ItemSet;
+    } else {
+        struct AncestorsSeen;
+
+        impl AncestorsSeen {
+            fn new() -> Self {
+                AncestorsSeen
+            }
+
+            fn contains(&self,_id: &ItemId) -> bool {
+                false
+            }
+
+            fn insert(&mut self, _id: ItemId) {}
+        }
+    }
+}
+
 /// An iterator over an item and its ancestors.
 pub struct ItemAncestorsIter<'a, 'b>
     where 'b: 'a,
 {
     item: ItemId,
     ctx: &'a BindgenContext<'b>,
+    seen: AncestorsSeen,
+}
+
+impl <'a, 'b> ItemAncestorsIter<'a, 'b>
+    where 'b: 'a
+{
+    fn new(ctx: &'a BindgenContext<'b>, item: ItemId) -> Self {
+        ItemAncestorsIter {
+            item: item,
+            ctx: ctx,
+            seen: AncestorsSeen::new(),
+        }
+    }
 }
 
 impl<'a, 'b> Iterator for ItemAncestorsIter<'a, 'b>
@@ -70,10 +103,15 @@ impl<'a, 'b> Iterator for ItemAncestorsIter<'a, 'b>
 
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.ctx.resolve_item(self.item);
+
         if item.parent_id() == self.item {
             None
         } else {
             self.item = item.parent_id();
+
+            debug_assert!(!self.seen.contains(&item.id()));
+            self.seen.insert(item.id());
+
             Some(item.id())
         }
     }
@@ -100,10 +138,7 @@ impl ItemAncestors for ItemId {
     fn ancestors<'a, 'b>(&self,
                          ctx: &'a BindgenContext<'b>)
                          -> ItemAncestorsIter<'a, 'b> {
-        ItemAncestorsIter {
-            item: *self,
-            ctx: ctx,
-        }
+        ItemAncestorsIter::new(ctx, *self)
     }
 }
 


### PR DESCRIPTION
In non-release builds with debug assertions, keep track of the set of
`ItemId`s that we have iterated over in `ItemAncestorsIter` and make
sure that we don't reach an ancestor we have already yielded, which
would trigger an infinite loop.