### PR TITLE
Upgrade clang-sys in libbindgen

### DIFF
--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -25,7 +25,7 @@ quasi_codegen = "0.21"
 
 [dependencies]
 cfg-if = "0.1.0"
-clang-sys = "0.8.0"
+clang-sys = "0.11.1"
 lazy_static = "0.1.*"
 libc = "0.2"
 rustc-serialize = "0.3.19"


### PR DESCRIPTION
It seems #322 doesn't upgrade the clang-sys of libbindgen, so bindgen is using two different versions of clang-sys. We should fix it.

r? @emilio 