### PR TITLE
Fix issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In `Cargo.toml`:
 
 ```toml
 [package]
-...
+# ...
 build = "build.rs"
 
 [build-dependencies.libbindgen]
@@ -95,12 +95,16 @@ In `build.rs`:
 ```rust
 extern crate libbindgen;
 
+use std::env;
+use std::path::Path;
+
 fn main() {
+  let out_dir = env::var("OUT_DIR").unwrap();
   let _ = libbindgen::builder()
     .header("example.h")
     .use_core()
     .generate().unwrap()
-    .write_to_file(concat!(env!("OUT_DIR"), "/example.rs"));
+    .write_to_file(Path::new(&out_dir).join("example.rs"));
 }
 ```
 


### PR DESCRIPTION
Mainly for fixing `env!("OUT_DIR")` usage in `build.rs`.