### PR TITLE
[rfc] Use a dynamically loaded clang to do as much as we can with old clang versions, and experiment with new ones.

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.17.0"
 workspace = ".."
 
 [dependencies]
-clang-sys = "0.11.1"
+clang-sys = "0.12"
 clap = "2"
 libbindgen = { path = "../libbindgen" }
 log = "0.3"

--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -26,7 +26,7 @@ quasi_codegen = "0.26"
 [dependencies]
 cexpr = "0.2"
 cfg-if = "0.1.0"
-clang-sys = { version = "0.11.1", features = ["gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9"] }
+clang-sys = { version = "0.12", features = ["runtime", "clang_3_9"] }
 lazy_static = "0.2.1"
 libc = "0.2"
 rustc-serialize = "0.3.19"

--- a/libbindgen/src/ir/ty.rs
+++ b/libbindgen/src/ir/ty.rs
@@ -854,7 +854,6 @@ impl Type {
                     .expect("Not able to resolve array element?");
                 TypeKind::Array(inner, ty.num_elements().unwrap())
             }
-            #[cfg(not(feature="llvm_stable"))]
             CXType_Elaborated => {
                 return Self::from_clang_ty(potential_id,
                                            &ty.named(),

--- a/libbindgen/src/lib.rs
+++ b/libbindgen/src/lib.rs
@@ -511,6 +511,10 @@ impl<'ctx> Bindings<'ctx> {
                     span: Option<Span>)
                     -> Result<Bindings<'ctx>, ()> {
         let span = span.unwrap_or(DUMMY_SP);
+        if !clang_sys::is_loaded() {
+            // TODO(emilio): Return meaningful error (breaking).
+            clang_sys::load().expect("Unable to find libclang");
+        }
 
         // TODO: Make this path fixup configurable?
         if let Some(clang) = clang_sys::support::Clang::find(None) {
@@ -691,6 +695,11 @@ pub struct ClangVersion {
 
 /// Get the major and the minor semvar numbers of Clang's version
 pub fn clang_version() -> ClangVersion {
+    if !clang_sys::is_loaded() {
+        // TODO(emilio): Return meaningful error (breaking).
+        clang_sys::load().expect("Unable to find libclang");
+    }
+
     let raw_v: String = clang::extract_clang_version();
     let split_v: Option<Vec<&str>> = raw_v.split_whitespace()
         .nth(2)


### PR DESCRIPTION
It's a pity that we don't support clang 3.7 and similar for generating C
bindings, when it should be straight-forward.

This change should allow us to support older clang versions, and also 
experiment with pre-release clang APIs if needed.

This depends on: https://github.com/KyleMayes/clang-sys/pull/44