### PR TITLE
Use a feature to control dangling item assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install: . ./ci/before_install.sh
 before_script: cd libbindgen
 
 script:
-  - cargo test --features "$BINDGEN_FEATURES"
-  - cargo test --release --features "$BINDGEN_FEATURES"
+  - cargo test --features "$BINDGEN_FEATURES assert_no_dangling_items"
+  - cargo test --release --features "$BINDGEN_FEATURES assert_no_dangling_items"
   - git add -A
   - git diff @
   - git diff-index --quiet HEAD

--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -50,6 +50,7 @@ features = ["with-syntex"]
 version = "0.26"
 
 [features]
+assert_no_dangling_items = []
 default = ["logging"]
 llvm_stable = []
 logging = ["env_logger", "log"]

--- a/libbindgen/src/ir/context.rs
+++ b/libbindgen/src/ir/context.rs
@@ -473,7 +473,7 @@ impl<'ctx> BindgenContext<'ctx> {
 
     /// This function trying to find any dangling references inside of `items`
     fn assert_no_dangling_references(&self) {
-        if cfg!(debug_assertions) {
+        if cfg!(feature = "assert_no_dangling_items") {
             for _ in self.assert_no_dangling_item_traversal() {
                 // The iterator's next method does the asserting for us.
             }


### PR DESCRIPTION
These checks are expensive enough that we only want to do them when hacking on
bindgen itself, not anytime someone does a debug build of something that depends
on bindgen.

r? @emilio 