### PR TITLE
Update to regex 0.2; use regex::RegexSet for matching

### DIFF
--- a/libbindgen/Cargo.toml
+++ b/libbindgen/Cargo.toml
@@ -30,7 +30,7 @@ clang-sys = { version = "0.12", features = ["runtime", "clang_3_9"] }
 lazy_static = "0.2.1"
 rustc-serialize = "0.3.19"
 syntex_syntax = "0.50"
-regex = "0.1"
+regex = "0.2"
 
 [dependencies.aster]
 features = ["with-syntex"]


### PR DESCRIPTION
Rather than implementing a private RegexSet, implement it in terms of regex::RegexSet,
which should be more efficient. Retain the existing RegexSet module and just reimplement
its internals, in order to preserve the external API.