### PR TITLE
Fix .gitignore and extra crates' Cargo.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Cargo
 target/
 *~
-./bindgen-integration/Cargo.lock
-./tests/expectations/Cargo.lock
+bindgen-integration/Cargo.lock
+tests/expectations/Cargo.lock
 #*#


### PR DESCRIPTION
The leading ./ breaks git, apparently. At least, they were still showing up as untracked files when I did git status.

r? @emilio or @Yamakaky 