### PR TITLE
Remove recently-added assertion that can legitimately trigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "bindgen"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "aster 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/servo/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-version = "0.20.4"
+version = "0.20.5"
 build = "build.rs"
 
 [badges]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -287,7 +287,12 @@ impl CodeGenerator for Item {
         }
 
         debug!("<Item as CodeGenerator>::codegen: self = {:?}", self);
-        assert!(whitelisted_items.contains(&self.id()));
+        if !whitelisted_items.contains(&self.id()) {
+            // TODO(emilio, #453): Figure out what to do when this happens
+            // legitimately, we could track the opaque stuff and disable the
+            // assertion there I guess.
+            error!("Found non-whitelisted item in code generation: {:?}", self);
+        }
 
         result.set_seen(self.id());
 


### PR DESCRIPTION
This fails under BaseErrorResult in Stylo builds.

I have no idea right now why that isn't whitelisted (should be, given we're
calling it from TErrorResult's code generation).

Let's disable this pending further investigation since I don't have time to dig
into it right now.

r? @fitzgen 