### PR TITLE
Added catch_unwind to catch panic at generator

### DIFF
--- a/src/chooser.rs
+++ b/src/chooser.rs
@@ -3,10 +3,11 @@
 pub use ir::int::IntKind;
 pub use ir::enum_ty::{EnumVariantValue, EnumVariantCustomBehavior};
 use std::fmt;
+use std::panic::UnwindSafe;
 
 /// A trait to allow configuring different kinds of types in different
 /// situations.
-pub trait TypeChooser: fmt::Debug {
+pub trait TypeChooser: fmt::Debug + UnwindSafe {
     /// The integer kind an integer macro should have, given a name and the
     /// value of that macro, or `None` if you want the default to be chosen.
     fn int_macro(&self, _name: &str, _value: i64) -> Option<IntKind> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,6 +555,11 @@ pub struct BindgenOptions {
     pub objc_extern_crate: bool,
 }
 
+/// TODO(emilio): This is sort of a lie (see the error message that results from
+/// removing this), but since we don't share references across panic boundaries
+/// it's ok.
+impl ::std::panic::UnwindSafe for BindgenOptions {}
+
 impl BindgenOptions {
     fn build(&mut self) {
         self.whitelisted_vars.build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,17 @@ impl Builder {
         self
     }
 
+    /// Set to output verbose messages
+    pub fn verbose(mut self) -> Self {
+        self.options.verbose = true;
+        self
+    }
+
+    /// Is set to output verbose messages
+    pub fn is_verbose(&self) -> bool {
+        return self.options.verbose;
+    }
+
     /// Generate the Rust bindings using the options built up thus far.
     pub fn generate<'ctx>(self) -> Result<Bindings<'ctx>, ()> {
         Bindings::generate(self.options, None)
@@ -543,16 +554,19 @@ pub struct BindgenOptions {
     /// See the builder method description for more details.
     pub conservative_inline_namespaces: bool,
 
-    /// Wether to keep documentation comments in the generated output. See the
+    /// Whether to keep documentation comments in the generated output. See the
     /// documentation for more details.
     pub generate_comments: bool,
 
-    /// Wether to whitelist types recursively. Defaults to true.
+    /// Whether to whitelist types recursively. Defaults to true.
     pub whitelist_recursively: bool,
 
     /// Intead of emitting 'use objc;' to files generated from objective c files,
     /// generate '#[macro_use] extern crate objc;'
     pub objc_extern_crate: bool,
+
+    /// Whether we should print verbose messages.
+    pub verbose: bool,
 }
 
 /// TODO(emilio): This is sort of a lie (see the error message that results from
@@ -605,6 +619,7 @@ impl Default for BindgenOptions {
             generate_comments: true,
             whitelist_recursively: true,
             objc_extern_crate: false,
+            verbose: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,17 +433,6 @@ impl Builder {
         self
     }
 
-    /// Set to output verbose messages
-    pub fn verbose(mut self) -> Self {
-        self.options.verbose = true;
-        self
-    }
-
-    /// Is set to output verbose messages
-    pub fn is_verbose(&self) -> bool {
-        return self.options.verbose;
-    }
-
     /// Generate the Rust bindings using the options built up thus far.
     pub fn generate<'ctx>(self) -> Result<Bindings<'ctx>, ()> {
         Bindings::generate(self.options, None)
@@ -554,19 +543,16 @@ pub struct BindgenOptions {
     /// See the builder method description for more details.
     pub conservative_inline_namespaces: bool,
 
-    /// Whether to keep documentation comments in the generated output. See the
+    /// Wether to keep documentation comments in the generated output. See the
     /// documentation for more details.
     pub generate_comments: bool,
 
-    /// Whether to whitelist types recursively. Defaults to true.
+    /// Wether to whitelist types recursively. Defaults to true.
     pub whitelist_recursively: bool,
 
     /// Intead of emitting 'use objc;' to files generated from objective c files,
     /// generate '#[macro_use] extern crate objc;'
     pub objc_extern_crate: bool,
-
-    /// Whether we should print verbose messages.
-    pub verbose: bool,
 }
 
 /// TODO(emilio): This is sort of a lie (see the error message that results from
@@ -619,7 +605,6 @@ impl Default for BindgenOptions {
             generate_comments: true,
             whitelist_recursively: true,
             objc_extern_crate: false,
-            verbose: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,8 @@ pub fn main() {
     }
 
     match builder_from_flags(bind_args.into_iter()) {
-        Ok((builder, output)) => {
+        Ok((builder, output, verbose)) => {
 
-            let verbose = (&builder).is_verbose();
             let builder_result =
                 panic::catch_unwind(||
                     builder.generate().expect("Unable to generate bindings")

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,19 +46,16 @@ pub fn main() {
     match builder_from_flags(bind_args.into_iter()) {
         Ok((builder, output)) => {
 
+            let verbose = (&builder).is_verbose();
             let builder_result =
                 panic::catch_unwind(||
                     builder.generate().expect("Unable to generate bindings")
                 );
 
             if builder_result.is_err() {
-                println!("Bindgen unexpectedly panicked");
-                println!("This may be caused by one of the known-unsupported \
-                          things (https://github.com/servo/rust-bindgen#c), \
-                          please modify the bindgen flags to work around it as \
-                          described in https://github.com/servo/rust-bindgen#c");
-                println!("Otherwise, please file an issue at \
-                         https://github.com/servo/rust-bindgen/issues/new");
+                if verbose {
+                    print_verbose_err();
+                }
                 std::process::exit(1);
             }
 
@@ -73,4 +70,14 @@ pub fn main() {
             std::process::exit(1);
         }
     };
+}
+
+fn print_verbose_err() {
+    println!("Bindgen unexpectedly panicked");
+    println!("This may be caused by one of the known-unsupported \
+              things (https://github.com/servo/rust-bindgen#c), \
+              please modify the bindgen flags to work around it as \
+              described in https://github.com/servo/rust-bindgen#c");
+    println!("Otherwise, please file an issue at \
+              https://github.com/servo/rust-bindgen/issues/new");
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,7 +5,7 @@ use std::io::{self, Error, ErrorKind};
 
 /// Construct a new [`Builder`](./struct.Builder.html) from command line flags.
 pub fn builder_from_flags<I>(args: I)
-                             -> Result<(Builder, Box<io::Write>), io::Error>
+                             -> Result<(Builder, Box<io::Write>, bool), io::Error>
     where I: Iterator<Item = String>,
 {
     let matches = App::new("bindgen")
@@ -349,9 +349,7 @@ pub fn builder_from_flags<I>(args: I)
         Box::new(io::BufWriter::new(io::stdout())) as Box<io::Write>
     };
 
-    if matches.is_present("verbose") {
-        builder = builder.verbose();
-    }
+    let verbose = matches.is_present("verbose");
 
-    Ok((builder, output))
+    Ok((builder, output, verbose))
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -175,6 +175,9 @@ pub fn builder_from_flags<I>(args: I)
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1),
+            Arg::with_name("verbose")
+                .long("verbose")
+                .help("Print verbose error messages"),
         ]) // .args()
         .get_matches_from(args);
 
@@ -345,6 +348,10 @@ pub fn builder_from_flags<I>(args: I)
     } else {
         Box::new(io::BufWriter::new(io::stdout())) as Box<io::Write>
     };
+
+    if matches.is_present("verbose") {
+        builder = builder.verbose();
+    }
 
     Ok((builder, output))
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -118,7 +118,7 @@ fn create_bindgen_builder(header: &PathBuf)
         .chain(flags.into_iter());
 
     builder_from_flags(args)
-        .map(|(builder, _)| Some(builder.no_unstable_rust()))
+        .map(|(builder, _, _)| Some(builder.no_unstable_rust()))
 }
 
 macro_rules! test_header {


### PR DESCRIPTION
#### What
Fixes #50 

- Adds a `catch_unwind` to catch panic at binding generation. 
- Prints out a more detailed message that points to the potential misuse of flags, when `generate()` fails.
- Added false-by-default `verbose` option flag to specify whether detailed message should be printed for the time being
 
#### Checks
- [x] Ran all test cases
- [x] Verified that correct error messages appear when bindings fail to generate
- [x] Verified use of verbose flag
- [x] Considered changes made by `cargo fmt`

r? @emilio 