### PR TITLE
Enhance Clang AST dumping

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -1316,13 +1316,6 @@ pub fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
             print_indent(depth, format!(" {}typedef-type = {}", prefix, type_to_str(ty.kind())));
         }
 
-        if let Some(def) = c.definition() {
-            if def != *c {
-                println!();
-                print_cursor(depth, String::from(prefix) + "definition.", &def);
-            }
-        }
-
         if let Some(refd) = c.referenced() {
             if refd != *c {
                 println!();


### PR DESCRIPTION
This commit extends our existing Clang AST dumping to include more information,
such as a cursor's canonical, referenced, and declarations cursors if they
exist. It prints out most of the information that libclang gives us directly,
but not the information that we attempt to (re)construct on top of the libclang
APIs.

r? @emilio or @Yamakaky 