### PR TITLE
ir: Don't parse non-semantic-children cursor as inner structs.

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -1482,9 +1482,6 @@ pub fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
                 print_cursor(depth,
                              String::from(prefix) + "referenced.",
                              &refd);
-                print_cursor(depth,
-                             String::from(prefix) + "referenced.",
-                             &refd);
             }
         }
 
@@ -1494,17 +1491,11 @@ pub fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
             print_cursor(depth,
                          String::from(prefix) + "canonical.",
                          &canonical);
-            print_cursor(depth,
-                         String::from(prefix) + "canonical.",
-                         &canonical);
         }
 
         if let Some(specialized) = c.specialized() {
             if specialized != *c {
                 println!("");
-                print_cursor(depth,
-                             String::from(prefix) + "specialized.",
-                             &specialized);
                 print_cursor(depth,
                              String::from(prefix) + "specialized.",
                              &specialized);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2190,7 +2190,7 @@ impl ToRustTy for Type {
                         .map(|arg| arg.to_rust_ty(ctx))
                         .collect::<Vec<_>>();
 
-                    path.segments.last_mut().unwrap().parameters = if 
+                    path.segments.last_mut().unwrap().parameters = if
                         template_args.is_empty() {
                         None
                     } else {

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -1026,9 +1026,7 @@ impl Type {
             CXType_MemberPointer |
             CXType_Pointer => {
                 let inner = Item::from_ty_or_ref(ty.pointee_type().unwrap(),
-                                                 location,
-                                                 parent_id,
-                                                 ctx);
+                                                 location, None, ctx);
                 TypeKind::Pointer(inner)
             }
             CXType_BlockPointer => TypeKind::BlockPointer,
@@ -1038,7 +1036,7 @@ impl Type {
             CXType_LValueReference => {
                 let inner = Item::from_ty_or_ref(ty.pointee_type().unwrap(),
                                                  location,
-                                                 parent_id,
+                                                 None,
                                                  ctx);
                 TypeKind::Reference(inner)
             }
@@ -1047,7 +1045,7 @@ impl Type {
             CXType_DependentSizedArray => {
                 let inner = Item::from_ty(ty.elem_type().as_ref().unwrap(),
                                           location,
-                                          parent_id,
+                                          None,
                                           ctx)
                     .expect("Not able to resolve array element?");
                 TypeKind::Pointer(inner)
@@ -1055,7 +1053,7 @@ impl Type {
             CXType_IncompleteArray => {
                 let inner = Item::from_ty(ty.elem_type().as_ref().unwrap(),
                                           location,
-                                          parent_id,
+                                          None,
                                           ctx)
                     .expect("Not able to resolve array element?");
                 TypeKind::Array(inner, 0)
@@ -1070,7 +1068,7 @@ impl Type {
             CXType_Typedef => {
                 let inner = cursor.typedef_type().expect("Not valid Type?");
                 let inner =
-                    Item::from_ty_or_ref(inner, location, parent_id, ctx);
+                    Item::from_ty_or_ref(inner, location, None, ctx);
                 TypeKind::Alias(inner)
             }
             CXType_Enum => {
@@ -1092,7 +1090,7 @@ impl Type {
             CXType_ConstantArray => {
                 let inner = Item::from_ty(ty.elem_type().as_ref().unwrap(),
                                           location,
-                                          parent_id,
+                                          None,
                                           ctx)
                     .expect("Not able to resolve array element?");
                 TypeKind::Array(inner, ty.num_elements().unwrap())

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -29,6 +29,34 @@ fn bindgen_test_layout_A_B() {
 impl Clone for A_B {
     fn clone(&self) -> Self { *self }
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct A_C {
+    pub baz: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_A_C() {
+    assert_eq!(::std::mem::size_of::<A_C>() , 4usize , concat ! (
+               "Size of: " , stringify ! ( A_C ) ));
+    assert_eq! (::std::mem::align_of::<A_C>() , 4usize , concat ! (
+                "Alignment of " , stringify ! ( A_C ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const A_C ) ) . baz as * const _ as usize } ,
+                0usize , concat ! (
+                "Alignment of field: " , stringify ! ( A_C ) , "::" ,
+                stringify ! ( baz ) ));
+}
+impl Clone for A_C {
+    fn clone(&self) -> Self { *self }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct A_D<T> {
+    pub foo: T,
+}
+impl <T> Default for A_D<T> {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
 #[test]
 fn bindgen_test_layout_A() {
     assert_eq!(::std::mem::size_of::<A>() , 4usize , concat ! (
@@ -47,6 +75,21 @@ impl Clone for A {
 extern "C" {
     #[link_name = "var"]
     pub static mut var: A_B;
+}
+#[test]
+fn __bindgen_test_layout_template_1() {
+    assert_eq!(::std::mem::size_of::<A_D<::std::os::raw::c_int>>() , 4usize ,
+               concat ! (
+               "Size of template specialization: " , stringify ! (
+               A_D<::std::os::raw::c_int> ) ));
+    assert_eq!(::std::mem::align_of::<A_D<::std::os::raw::c_int>>() , 4usize ,
+               concat ! (
+               "Alignment of template specialization: " , stringify ! (
+               A_D<::std::os::raw::c_int> ) ));
+}
+extern "C" {
+    #[link_name = "baz"]
+    pub static mut baz: A_D<::std::os::raw::c_int>;
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy)]

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -200,7 +200,7 @@ pub struct malloc_heap {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct malloc_heap__bindgen_ty_1 {
-    pub lh_first: *mut malloc_heap__bindgen_ty_1_malloc_elem,
+    pub lh_first: *mut malloc_elem,
 }
 #[test]
 fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
@@ -254,4 +254,12 @@ impl Clone for malloc_heap {
 }
 impl Default for malloc_heap {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct malloc_elem {
+    pub _address: u8,
+}
+impl Clone for malloc_elem {
+    fn clone(&self) -> Self { *self }
 }

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -202,9 +202,6 @@ pub struct malloc_heap {
 pub struct malloc_heap__bindgen_ty_1 {
     pub lh_first: *mut malloc_heap__bindgen_ty_1_malloc_elem,
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct malloc_heap__bindgen_ty_1_malloc_elem([u8; 0]);
 #[test]
 fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     assert_eq!(::std::mem::size_of::<malloc_heap__bindgen_ty_1>() , 8usize ,

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -11,9 +11,33 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct cmdline_token_hdr {
-    pub ops: *mut cmdline_token_hdr_cmdline_token_ops,
+    pub ops: *mut cmdline_token_ops,
     pub offset: ::std::os::raw::c_uint,
 }
+#[test]
+fn bindgen_test_layout_cmdline_token_hdr() {
+    assert_eq!(::std::mem::size_of::<cmdline_token_hdr>() , 16usize , concat !
+               ( "Size of: " , stringify ! ( cmdline_token_hdr ) ));
+    assert_eq! (::std::mem::align_of::<cmdline_token_hdr>() , 8usize , concat
+                ! ( "Alignment of " , stringify ! ( cmdline_token_hdr ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const cmdline_token_hdr ) ) . ops as * const _
+                as usize } , 0usize , concat ! (
+                "Alignment of field: " , stringify ! ( cmdline_token_hdr ) ,
+                "::" , stringify ! ( ops ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const cmdline_token_hdr ) ) . offset as * const
+                _ as usize } , 8usize , concat ! (
+                "Alignment of field: " , stringify ! ( cmdline_token_hdr ) ,
+                "::" , stringify ! ( offset ) ));
+}
+impl Clone for cmdline_token_hdr {
+    fn clone(&self) -> Self { *self }
+}
+impl Default for cmdline_token_hdr {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type cmdline_parse_token_hdr_t = cmdline_token_hdr;
 /**
  * A token is defined by this structure.
  *
@@ -35,7 +59,7 @@ pub struct cmdline_token_hdr {
  */
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct cmdline_token_hdr_cmdline_token_ops {
+pub struct cmdline_token_ops {
     /** parse(token ptr, buf, res pts, buf len) */
     pub parse: ::std::option::Option<unsafe extern "C" fn(arg1:
                                                               *mut cmdline_parse_token_hdr_t,
@@ -70,71 +94,38 @@ pub struct cmdline_token_hdr_cmdline_token_ops {
                                             -> ::std::os::raw::c_int>,
 }
 #[test]
-fn bindgen_test_layout_cmdline_token_hdr_cmdline_token_ops() {
-    assert_eq!(::std::mem::size_of::<cmdline_token_hdr_cmdline_token_ops>() ,
-               32usize , concat ! (
-               "Size of: " , stringify ! ( cmdline_token_hdr_cmdline_token_ops
-               ) ));
-    assert_eq! (::std::mem::align_of::<cmdline_token_hdr_cmdline_token_ops>()
-                , 8usize , concat ! (
-                "Alignment of " , stringify ! (
-                cmdline_token_hdr_cmdline_token_ops ) ));
+fn bindgen_test_layout_cmdline_token_ops() {
+    assert_eq!(::std::mem::size_of::<cmdline_token_ops>() , 32usize , concat !
+               ( "Size of: " , stringify ! ( cmdline_token_ops ) ));
+    assert_eq! (::std::mem::align_of::<cmdline_token_ops>() , 8usize , concat
+                ! ( "Alignment of " , stringify ! ( cmdline_token_ops ) ));
     assert_eq! (unsafe {
-                & ( * ( 0 as * const cmdline_token_hdr_cmdline_token_ops ) ) .
-                parse as * const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                cmdline_token_hdr_cmdline_token_ops ) , "::" , stringify ! (
-                parse ) ));
+                & ( * ( 0 as * const cmdline_token_ops ) ) . parse as * const
+                _ as usize } , 0usize , concat ! (
+                "Alignment of field: " , stringify ! ( cmdline_token_ops ) ,
+                "::" , stringify ! ( parse ) ));
     assert_eq! (unsafe {
-                & ( * ( 0 as * const cmdline_token_hdr_cmdline_token_ops ) ) .
-                complete_get_nb as * const _ as usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                cmdline_token_hdr_cmdline_token_ops ) , "::" , stringify ! (
-                complete_get_nb ) ));
+                & ( * ( 0 as * const cmdline_token_ops ) ) . complete_get_nb
+                as * const _ as usize } , 8usize , concat ! (
+                "Alignment of field: " , stringify ! ( cmdline_token_ops ) ,
+                "::" , stringify ! ( complete_get_nb ) ));
     assert_eq! (unsafe {
-                & ( * ( 0 as * const cmdline_token_hdr_cmdline_token_ops ) ) .
-                complete_get_elt as * const _ as usize } , 16usize , concat !
-                (
-                "Alignment of field: " , stringify ! (
-                cmdline_token_hdr_cmdline_token_ops ) , "::" , stringify ! (
-                complete_get_elt ) ));
+                & ( * ( 0 as * const cmdline_token_ops ) ) . complete_get_elt
+                as * const _ as usize } , 16usize , concat ! (
+                "Alignment of field: " , stringify ! ( cmdline_token_ops ) ,
+                "::" , stringify ! ( complete_get_elt ) ));
     assert_eq! (unsafe {
-                & ( * ( 0 as * const cmdline_token_hdr_cmdline_token_ops ) ) .
-                get_help as * const _ as usize } , 24usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                cmdline_token_hdr_cmdline_token_ops ) , "::" , stringify ! (
-                get_help ) ));
+                & ( * ( 0 as * const cmdline_token_ops ) ) . get_help as *
+                const _ as usize } , 24usize , concat ! (
+                "Alignment of field: " , stringify ! ( cmdline_token_ops ) ,
+                "::" , stringify ! ( get_help ) ));
 }
-impl Clone for cmdline_token_hdr_cmdline_token_ops {
+impl Clone for cmdline_token_ops {
     fn clone(&self) -> Self { *self }
 }
-impl Default for cmdline_token_hdr_cmdline_token_ops {
+impl Default for cmdline_token_ops {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
-#[test]
-fn bindgen_test_layout_cmdline_token_hdr() {
-    assert_eq!(::std::mem::size_of::<cmdline_token_hdr>() , 16usize , concat !
-               ( "Size of: " , stringify ! ( cmdline_token_hdr ) ));
-    assert_eq! (::std::mem::align_of::<cmdline_token_hdr>() , 8usize , concat
-                ! ( "Alignment of " , stringify ! ( cmdline_token_hdr ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const cmdline_token_hdr ) ) . ops as * const _
-                as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( cmdline_token_hdr ) ,
-                "::" , stringify ! ( ops ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const cmdline_token_hdr ) ) . offset as * const
-                _ as usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! ( cmdline_token_hdr ) ,
-                "::" , stringify ! ( offset ) ));
-}
-impl Clone for cmdline_token_hdr {
-    fn clone(&self) -> Self { *self }
-}
-impl Default for cmdline_token_hdr {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
-}
-pub type cmdline_parse_token_hdr_t = cmdline_token_hdr;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum cmdline_numtype {

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -98,7 +98,7 @@ pub struct rte_mbuf {
     pub cacheline1: MARKER,
     pub __bindgen_anon_3: rte_mbuf__bindgen_ty_4,
     /**< Pool from which mbuf was allocated. */
-    pub pool: *mut rte_mbuf_rte_mempool,
+    pub pool: *mut rte_mempool,
     /**< Next segment of scattered packet. */
     pub next: *mut rte_mbuf,
     pub __bindgen_anon_4: rte_mbuf__bindgen_ty_5,
@@ -730,4 +730,13 @@ impl Clone for rte_mbuf {
 }
 impl Default for rte_mbuf {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+/**< Pool from which mbuf was allocated. */
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct rte_mempool {
+    pub _address: u8,
+}
+impl Clone for rte_mempool {
+    fn clone(&self) -> Self { *self }
 }

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -490,9 +490,6 @@ impl Clone for rte_mbuf__bindgen_ty_4 {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rte_mbuf_rte_mempool([u8; 0]);
-#[repr(C)]
 #[derive(Debug, Default, Copy)]
 pub struct rte_mbuf__bindgen_ty_5 {
     /**< combined for easy fetch */

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -7,27 +7,7 @@
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct a {
-    pub val_a: *mut a_b,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy)]
-pub struct a_b {
-    pub val_b: ::std::os::raw::c_int,
-}
-#[test]
-fn bindgen_test_layout_a_b() {
-    assert_eq!(::std::mem::size_of::<a_b>() , 4usize , concat ! (
-               "Size of: " , stringify ! ( a_b ) ));
-    assert_eq! (::std::mem::align_of::<a_b>() , 4usize , concat ! (
-                "Alignment of " , stringify ! ( a_b ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const a_b ) ) . val_b as * const _ as usize } ,
-                0usize , concat ! (
-                "Alignment of field: " , stringify ! ( a_b ) , "::" ,
-                stringify ! ( val_b ) ));
-}
-impl Clone for a_b {
-    fn clone(&self) -> Self { *self }
+    pub val_a: *mut b,
 }
 #[test]
 fn bindgen_test_layout_a() {
@@ -46,4 +26,24 @@ impl Clone for a {
 }
 impl Default for a {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct b {
+    pub val_b: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_b() {
+    assert_eq!(::std::mem::size_of::<b>() , 4usize , concat ! (
+               "Size of: " , stringify ! ( b ) ));
+    assert_eq! (::std::mem::align_of::<b>() , 4usize , concat ! (
+                "Alignment of " , stringify ! ( b ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const b ) ) . val_b as * const _ as usize } ,
+                0usize , concat ! (
+                "Alignment of field: " , stringify ! ( b ) , "::" , stringify
+                ! ( val_b ) ));
+}
+impl Clone for b {
+    fn clone(&self) -> Self { *self }
 }

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -258,6 +258,17 @@ fn __bindgen_test_layout_template_1() {
 }
 #[test]
 fn __bindgen_test_layout_template_2() {
+    assert_eq!(::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>() ,
+               24usize , concat ! (
+               "Size of template specialization: " , stringify ! (
+               Rooted<*mut ::std::os::raw::c_void> ) ));
+    assert_eq!(::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>() ,
+               8usize , concat ! (
+               "Alignment of template specialization: " , stringify ! (
+               Rooted<*mut ::std::os::raw::c_void> ) ));
+}
+#[test]
+fn __bindgen_test_layout_template_3() {
     assert_eq!(::std::mem::size_of::<WithDtor<::std::os::raw::c_int>>() ,
                4usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/headers/class_nested.hpp
+++ b/tests/headers/class_nested.hpp
@@ -4,9 +4,21 @@ public:
     class B {
         int member_b;
     };
+
+    class C;
+
+    template<typename T>
+    class D {
+      T foo;
+    };
+};
+
+class A::C {
+  int baz;
 };
 
 A::B var;
+A::D<int> baz;
 
 class D {
     A::B member;


### PR DESCRIPTION
r? @fitzgen 