### PR TITLE
Support older clang

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -879,7 +879,11 @@ impl Type {
     pub fn named(&self) -> Type {
         unsafe {
             Type {
-                x: clang_Type_getNamedType(self.x),
+                x: if clang_Type_getNamedType::is_loaded() {
+                    clang_Type_getNamedType(self.x)
+                } else {
+                    self.x
+                },
             }
         }
     }


### PR DESCRIPTION
Clang on macOS Sierra doesn't have `clang_getCanonicalType`. It's used only when dumping clang AST, so I hope the fudge is acceptable.