### PR TITLE
Disable osx testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 
 os:
   - linux
-  - osx
 
 rust:
   - stable


### PR DESCRIPTION
Not only for the large build times, but also because builds have been stalled
for long, and I had to merge a few PRs manually already.

r? @fitzgen 