### PR TITLE
Gotta land some of this stuff...

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -871,7 +871,7 @@ impl CompInfo {
 }
 
 impl TemplateDeclaration for CompInfo {
-    fn template_params(&self, _ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+    fn self_template_params(&self, _ctx: &BindgenContext) -> Option<Vec<ItemId>> {
         if self.template_args.is_empty() {
             None
         } else {

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -1040,10 +1040,10 @@ impl Trace for CompInfo {
         if let Some(template) = self.specialized_template() {
             // This is an instantiation of a template declaration with concrete
             // template type arguments.
-            tracer.visit(template);
+            tracer.visit_kind(template, EdgeKind::TemplateDeclaration);
             let args = item.applicable_template_args(context);
             for a in args {
-                tracer.visit(a);
+                tracer.visit_kind(a, EdgeKind::TemplateArgument);
             }
         } else {
             let params = item.applicable_template_args(context);
@@ -1055,27 +1055,27 @@ impl Trace for CompInfo {
         }
 
         for base in self.base_members() {
-            tracer.visit(base.ty);
+            tracer.visit_kind(base.ty, EdgeKind::BaseMember);
         }
 
         for field in self.fields() {
-            tracer.visit(field.ty());
+            tracer.visit_kind(field.ty(), EdgeKind::Field);
         }
 
         for &ty in self.inner_types() {
-            tracer.visit(ty);
+            tracer.visit_kind(ty, EdgeKind::InnerType);
         }
 
         for &var in self.inner_vars() {
-            tracer.visit(var);
+            tracer.visit_kind(var, EdgeKind::InnerVar);
         }
 
         for method in self.methods() {
-            tracer.visit(method.signature);
+            tracer.visit_kind(method.signature, EdgeKind::Method);
         }
 
         for &ctor in self.constructors() {
-            tracer.visit(ctor);
+            tracer.visit_kind(ctor, EdgeKind::Constructor);
         }
     }
 }

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -634,7 +634,7 @@ impl<'ctx> BindgenContext<'ctx> {
             .and_then(|canon_decl| {
                 self.get_resolved_type(&canon_decl)
                     .and_then(|template_decl_id| {
-                        template_decl_id.num_template_params(self)
+                        template_decl_id.num_self_template_params(self)
                             .map(|num_params| {
                                 (*canon_decl.cursor(),
                                  template_decl_id,
@@ -658,7 +658,7 @@ impl<'ctx> BindgenContext<'ctx> {
                             .cloned()
                     })
                     .and_then(|template_decl| {
-                        template_decl.num_template_params(self)
+                        template_decl.num_self_template_params(self)
                             .map(|num_template_params| {
                                 (*template_decl.decl(),
                                  template_decl.id(),
@@ -706,7 +706,7 @@ impl<'ctx> BindgenContext<'ctx> {
         use clang_sys;
 
         let num_expected_args = match self.resolve_type(template)
-            .num_template_params(self) {
+            .num_self_template_params(self) {
             Some(n) => n,
             None => {
                 warn!("Tried to instantiate a template for which we could not \
@@ -1331,13 +1331,13 @@ impl PartialType {
 }
 
 impl TemplateDeclaration for PartialType {
-    fn template_params(&self, _ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+    fn self_template_params(&self, _ctx: &BindgenContext) -> Option<Vec<ItemId>> {
         // Maybe at some point we will eagerly parse named types, but for now we
         // don't and this information is unavailable.
         None
     }
 
-    fn num_template_params(&self, _ctx: &BindgenContext) -> Option<usize> {
+    fn num_self_template_params(&self, _ctx: &BindgenContext) -> Option<usize> {
         // Wouldn't it be nice if libclang would reliably give us this
         // information‽
         match self.decl().kind() {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -3,7 +3,7 @@
 use super::context::{BindgenContext, ItemId};
 use super::dot::DotAttributes;
 use super::item::Item;
-use super::traversal::{Trace, Tracer};
+use super::traversal::{EdgeKind, Trace, Tracer};
 use super::ty::TypeKind;
 use clang;
 use clang_sys::CXCallingConv;
@@ -336,10 +336,10 @@ impl Trace for FunctionSig {
     fn trace<T>(&self, _: &BindgenContext, tracer: &mut T, _: &())
         where T: Tracer,
     {
-        tracer.visit(self.return_type());
+        tracer.visit_kind(self.return_type(), EdgeKind::FunctionReturn);
 
         for &(_, ty) in self.argument_types() {
-            tracer.visit(ty);
+            tracer.visit_kind(ty, EdgeKind::FunctionParameter);
         }
     }
 }

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -7,7 +7,7 @@ use super::dot::{DotAttributes};
 use super::function::Function;
 use super::item_kind::ItemKind;
 use super::module::Module;
-use super::traversal::{Trace, Tracer};
+use super::traversal::{EdgeKind, Trace, Tracer};
 use super::ty::{TemplateDeclaration, Type, TypeKind};
 use clang;
 use clang_sys;
@@ -205,7 +205,7 @@ impl Trace for Item {
                 tracer.visit(fun.signature());
             }
             ItemKind::Var(ref var) => {
-                tracer.visit(var.ty());
+                tracer.visit_kind(var.ty(), EdgeKind::VarType);
             }
             ItemKind::Module(_) => {
                 // Module -> children edges are "weak", and we do not want to

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -930,22 +930,22 @@ impl DotAttributes for Item {
 }
 
 impl TemplateDeclaration for ItemId {
-    fn template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+    fn self_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
         ctx.resolve_item_fallible(*self)
-            .and_then(|item| item.template_params(ctx))
+            .and_then(|item| item.self_template_params(ctx))
     }
 }
 
 impl TemplateDeclaration for Item {
-    fn template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
-        self.kind.template_params(ctx)
+    fn self_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+        self.kind.self_template_params(ctx)
     }
 }
 
 impl TemplateDeclaration for ItemKind {
-    fn template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+    fn self_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
         match *self {
-            ItemKind::Type(ref ty) => ty.template_params(ctx),
+            ItemKind::Type(ref ty) => ty.self_template_params(ctx),
             // If we start emitting bindings to explicitly instantiated
             // functions, then we'll need to check ItemKind::Function for
             // template params.

--- a/src/ir/named.rs
+++ b/src/ir/named.rs
@@ -208,7 +208,7 @@ impl<'a> MonotoneFramework for UsedTemplateParameters<'a> {
                 .map(|ty| match ty.kind() {
                     &TypeKind::TemplateInstantiation(decl, ref args) => {
                         let decl = ctx.resolve_type(decl);
-                        let params = decl.template_params(ctx)
+                        let params = decl.self_template_params(ctx)
                             .expect("a template instantiation's referenced \
                                      template declaration should have template \
                                      parameters");
@@ -255,7 +255,7 @@ impl<'a> MonotoneFramework for UsedTemplateParameters<'a> {
                     // only used if the template declaration uses the
                     // corresponding template parameter.
                     let decl = self.ctx.resolve_type(decl);
-                    let params = decl.template_params(self.ctx)
+                    let params = decl.self_template_params(self.ctx)
                         .expect("a template instantiation's referenced \
                                  template declaration should have template \
                                  parameters");

--- a/src/ir/traversal.rs
+++ b/src/ir/traversal.rs
@@ -44,22 +44,137 @@ impl Into<ItemId> for Edge {
 }
 
 /// The kind of edge reference. This is useful when we wish to only consider
-/// certain kinds of edges for a particular traversal.
+/// certain kinds of edges for a particular traversal or analysis.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum EdgeKind {
     /// A generic, catch-all edge.
     Generic,
 
     /// An edge from a template declaration, to the definition of a named type
-    /// parameter. For example, the edge Foo -> T in the following snippet:
+    /// parameter. For example, the edge from `Foo<T>` to `T` in the following
+    /// snippet:
     ///
     /// ```C++
     /// template<typename T>
+    /// class Foo { };
+    /// ```
+    TemplateParameterDefinition,
+
+    /// An edge from a template instantiation to the template declaration that
+    /// is being instantiated. For example, the edge from `Foo<int>` to
+    /// to `Foo<T>`:
+    ///
+    /// ```C++
+    /// template<typename T>
+    /// class Foo { };
+    ///
+    /// using Bar = Foo<int>;
+    /// ```
+    TemplateDeclaration,
+
+    /// An edge from a template instantiation to its template argument. For
+    /// example, `Foo<Bar>` to `Bar`:
+    ///
+    /// ```C++
+    /// template<typename T>
+    /// class Foo { };
+    ///
+    /// class Bar { };
+    ///
+    /// using FooBar = Foo<Bar>;
+    /// ```
+    TemplateArgument,
+
+    /// An edge from a compound type to one of its base member types. For
+    /// example, the edge from `Bar` to `Foo`:
+    ///
+    /// ```C++
+    /// class Foo { };
+    ///
+    /// class Bar : public Foo { };
+    /// ```
+    BaseMember,
+
+    /// An edge from a compound type to the types of one of its fields. For
+    /// example, the edge from `Foo` to `int`:
+    ///
+    /// ```C++
     /// class Foo {
     ///     int x;
     /// };
     /// ```
-    TemplateParameterDefinition,
+    Field,
+
+    /// An edge from an class or struct type to an inner type member. For
+    /// example, the edge from `Foo` to `Foo::Bar` here:
+    ///
+    /// ```C++
+    /// class Foo {
+    ///     struct Bar { };
+    /// };
+    /// ```
+    InnerType,
+
+    /// An edge from an class or struct type to an inner static variable. For
+    /// example, the edge from `Foo` to `Foo::BAR` here:
+    ///
+    /// ```C++
+    /// class Foo {
+    ///     static const char* BAR;
+    /// };
+    /// ```
+    InnerVar,
+
+    /// An edge from a class or struct type to one of its method functions. For
+    /// example, the edge from `Foo` to `Foo::bar`:
+    ///
+    /// ```C++
+    /// class Foo {
+    ///     bool bar(int x, int y);
+    /// };
+    /// ```
+    Method,
+
+    /// An edge from a class or struct type to one of its constructor
+    /// functions. For example, the edge from `Foo` to `Foo::Foo(int x, int y)`:
+    ///
+    /// ```C++
+    /// class Foo {
+    ///     int my_x;
+    ///     int my_y;
+    ///
+    ///   public:
+    ///     Foo(int x, int y);
+    /// };
+    /// ```
+    Constructor,
+
+    /// An edge from a function declaration to its return type. For example, the
+    /// edge from `foo` to `int`:
+    ///
+    /// ```C++
+    /// int foo(char* string);
+    /// ```
+    FunctionReturn,
+
+    /// An edge from a function declaration to one of its parameter types. For
+    /// example, the edge from `foo` to `char*`:
+    ///
+    /// ```C++
+    /// int foo(char* string);
+    /// ```
+    FunctionParameter,
+
+    /// An edge from a static variable to its type. For example, the edge from
+    /// `FOO` to `const char*`:
+    ///
+    /// ```C++
+    /// static const char* FOO;
+    /// ```
+    VarType,
+
+    /// An edge from a non-templated alias or typedef to the referenced type.
+    TypeReference,
 }
 
 /// A predicate to allow visiting only sub-sets of the whole IR graph by
@@ -211,7 +326,8 @@ impl<F> Tracer for F
 }
 
 /// Trace all of the outgoing edges to other items. Implementations should call
-/// `tracer.visit(edge)` for each of their outgoing edges.
+/// one of `tracer.visit(edge)` or `tracer.visit_kind(edge, EdgeKind::Whatever)`
+/// for each of their outgoing edges.
 pub trait Trace {
     /// If a particular type needs extra information beyond what it has in
     /// `self` and `context` to find its referenced items, its implementation

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -22,10 +22,11 @@ pub trait TemplateDeclaration {
     /// template parameters.
     ///
     /// Note that these might *not* all be named types: C++ allows
-    /// constant-value template parameters. Of course, Rust does not allow
-    /// generic parameters to be anything but types, so we must treat them as
-    /// opaque, and avoid instantiating them.
-    fn template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>>;
+    /// constant-value template parameters as well as template-template
+    /// parameters. Of course, Rust does not allow generic parameters to be
+    /// anything but types, so we must treat them as opaque, and avoid
+    /// instantiating them.
+    fn self_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>>;
 
     /// Get the number of free template parameters this template declaration
     /// has.
@@ -34,8 +35,8 @@ pub trait TemplateDeclaration {
     /// `template_params` returns `None`. This is useful when we only have
     /// partial information about the template declaration, such as when we are
     /// in the middle of parsing it.
-    fn num_template_params(&self, ctx: &BindgenContext) -> Option<usize> {
-        self.template_params(ctx).map(|params| params.len())
+    fn num_self_template_params(&self, ctx: &BindgenContext) -> Option<usize> {
+        self.self_template_params(ctx).map(|params| params.len())
     }
 }
 
@@ -487,18 +488,18 @@ fn is_invalid_named_type_empty_name() {
 
 
 impl TemplateDeclaration for Type {
-    fn template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
-        self.kind.template_params(ctx)
+    fn self_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+        self.kind.self_template_params(ctx)
     }
 }
 
 impl TemplateDeclaration for TypeKind {
-    fn template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
+    fn self_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>> {
         match *self {
             TypeKind::ResolvedTypeRef(id) => {
-                ctx.resolve_type(id).template_params(ctx)
+                ctx.resolve_type(id).self_template_params(ctx)
             }
-            TypeKind::Comp(ref comp) => comp.template_params(ctx),
+            TypeKind::Comp(ref comp) => comp.self_template_params(ctx),
             TypeKind::TemplateAlias(_, ref args) => Some(args.clone()),
 
             TypeKind::TemplateInstantiation(..) |

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -7,7 +7,7 @@ use super::dot::DotAttributes;
 use super::enum_ty::Enum;
 use super::function::FunctionSig;
 use super::int::IntKind;
-use super::item::Item;
+use super::item::{Item, ItemAncestors};
 use super::layout::Layout;
 use super::objc::ObjCInterface;
 use super::traversal::{Trace, Tracer};
@@ -16,7 +16,40 @@ use parse::{ClangItemParser, ParseError, ParseResult};
 use std::io;
 use std::mem;
 
-/// Template declaration related methods.
+/// Template declaration (and such declaration's template parameters) related
+/// methods.
+///
+/// Consider this example:
+///
+/// ```c++
+/// template <typename T, typename U>
+/// class Foo {
+///     template <typename V>
+///     using Bar = V*;
+///
+///     class Inner {
+///         T        x;
+///         U        y;
+///         Bar<int> z;
+///     };
+/// };
+///
+/// class Qux {
+///     int y;
+/// };
+/// ```
+///
+/// The following table depicts the results of each trait method when invoked on
+/// `Foo`, `Bar`, and `Qux`.
+///
+/// +------+----------------------+--------------------------+------------------------+
+/// |Decl. | self_template_params | num_self_template_params | all_template_parameters|
+/// +------+----------------------+--------------------------+------------------------+
+/// |Foo   | Some([T, U])         | Some(2)                  | Some([T, U])           |
+/// |Bar   | Some([V])            | Some(1)                  | Some([T, U, V])        |
+/// |Inner | None                 | None                     | Some([T, U])           |
+/// |Qux   | None                 | None                     | None                   |
+/// +------+----------------------+--------------------------+------------------------+
 pub trait TemplateDeclaration {
     /// Get the set of `ItemId`s that make up this template declaration's free
     /// template parameters.
@@ -37,6 +70,36 @@ pub trait TemplateDeclaration {
     /// in the middle of parsing it.
     fn num_self_template_params(&self, ctx: &BindgenContext) -> Option<usize> {
         self.self_template_params(ctx).map(|params| params.len())
+    }
+
+    /// Get the complete set of template parameters that can affect this
+    /// declaration.
+    ///
+    /// Note that this item doesn't need to be a template declaration itself for
+    /// `Some` to be returned here (in contrast to `self_template_params`). If
+    /// this item is a member of a template declaration, then the parent's
+    /// template parameters are included here.
+    ///
+    /// In the example above, `Inner` depends on both of the `T` and `U` type
+    /// parameters, even though it is not itself a template declaration and
+    /// therefore has no type parameters itself. Perhaps it helps to think about
+    /// how we would fully reference such a member type in C++:
+    /// `Foo<int,char>::Inner`. `Foo` *must* be instantiated with template
+    /// arguments before we can gain access to the `Inner` member type.
+    fn all_template_params(&self, ctx: &BindgenContext) -> Option<Vec<ItemId>>
+        where Self: ItemAncestors
+    {
+        let each_self_params: Vec<Vec<_>> = self.ancestors(ctx)
+            .filter_map(|id| id.self_template_params(ctx))
+            .collect();
+        if each_self_params.is_empty() {
+            None
+        } else {
+            Some(each_self_params.into_iter()
+                 .rev()
+                 .flat_map(|params| params)
+                 .collect())
+        }
     }
 }
 


### PR DESCRIPTION
My patch queue is getting quite large, as I refactor templates in bindgen, so I figure I should land the stuff that is in good shape sooner rather than later :-P

This stuff tweaks the named template parameter analysis, adds some edge kinds, stuff like that. This is still not used by codegen, yet. I have another branch where I de-dupe named types and all of that, and there is only two tests failing now, but still some clean up needed.

This also contains the expanded documentation for te named template parameter analysis that I promised.

See each commit message for details.

r? @emilio 