### PR TITLE
clang: Avoid a hot FFI call for getting the cursor kind.

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -208,7 +208,7 @@ impl Cursor {
 
     /// Get the kind of referent this cursor is pointing to.
     pub fn kind(&self) -> CXCursorKind {
-        unsafe { clang_getCursorKind(self.x) }
+        self.x.kind
     }
 
     /// Returns true is the cursor is a definition


### PR DESCRIPTION
This is a sorta-hot call already.

I've noticed #544 wants to add more assertions about this, and was going to
suggest moving them to `debug_assert!`.

But there's an easier way :)

r? @fitzgen 