### PR TITLE
fix clang installation instruction for debian os

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ port install clang-3.9
 ##### Debian-based Linuxes
 
 ```
-# apt-get install llvm-3.9-dev libclang-3.9-dev
+# apt-get install llvm-3.9-dev libclang-3.9-dev clang-3.9
 ```
 
 Ubuntu 16.10 provides the necessary packages directly. If you are using older


### PR DESCRIPTION
Added clang-3.9 to debian install command. Without it, `cargo build` of [libbindgen-tutorial-bzip2-sys](https://github.com/fitzgen/libbindgen-tutorial-bzip2-sys) fails with:
```
/usr/include/stdio.h:33:11:` fatal error: 'stddef.h' file not found, err: true
```
