### PR TITLE
automatically allow non rust naming conventions

### DIFF
--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -10,6 +10,10 @@ pub mod attributes {
     use aster;
     use syntax::ast;
 
+    pub fn allow(which_ones: &[&str]) -> ast::Attribute {
+        aster::AstBuilder::new().attr().list("allow").words(which_ones).build()
+    }
+
     pub fn repr(which: &str) -> ast::Attribute {
         aster::AstBuilder::new().attr().list("repr").words(&[which]).build()
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -403,10 +403,18 @@ impl CodeGenerator for Module {
         });
 
         let name = item.canonical_name(ctx);
-        let item = aster::AstBuilder::new()
+        let item_builder = aster::AstBuilder::new()
             .item()
-            .pub_()
-            .build_item_kind(name, module);
+            .pub_();
+        let item = if name == "root" {
+            let attrs = &["non_snake_case",
+                "non_camel_case_types",
+                "non_upper_case_globals"];
+            item_builder.with_attr(attributes::allow(attrs))
+                .build_item_kind(name, module)
+        } else {
+            item_builder.build_item_kind(name, module)
+        };
 
         result.push(item);
     }

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/duplicated-namespaces.rs
+++ b/tests/expectations/tests/duplicated-namespaces.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/duplicated_constants_in_ns.rs
+++ b/tests/expectations/tests/duplicated_constants_in_ns.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/inline_namespace_whitelist.rs
+++ b/tests/expectations/tests/inline_namespace_whitelist.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/issue-410.rs
+++ b/tests/expectations/tests/issue-410.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/issue-447.rs
+++ b/tests/expectations/tests/issue-447.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/issue_311.rs
+++ b/tests/expectations/tests/issue_311.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/module-whitelisted.rs
+++ b/tests/expectations/tests/module-whitelisted.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/template_alias_namespace.rs
+++ b/tests/expectations/tests/template_alias_namespace.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[repr(C)]
     pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);

--- a/tests/expectations/tests/whitelist-namespaces-basic.rs
+++ b/tests/expectations/tests/whitelist-namespaces-basic.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;

--- a/tests/expectations/tests/whitelist-namespaces.rs
+++ b/tests/expectations/tests/whitelist-namespaces.rs
@@ -4,6 +4,7 @@
 #![allow(non_snake_case)]
 
 
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
     #[allow(unused_imports)]
     use self::super::root;


### PR DESCRIPTION
+ related issue: #562 

I just added those attributes at the root mod. And I'm not sure whether it should be better if we could set this setting in `build.rs`.