### PR TITLE
Do not print builtin macro definitions in ast_dump

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -80,7 +80,7 @@ impl Cursor {
     /// Returns whether the cursor refers to a built-in definition.
     pub fn is_builtin(&self) -> bool {
         let (file, _, _, _) = self.location().location();
-        !file.name().is_some()
+        file.name().is_none()
     }
 
     /// Get the `Cursor` for this cursor's referent's lexical parent.

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -77,6 +77,12 @@ impl Cursor {
         }
     }
 
+    /// Returns whether the cursor refers to a built-in definition.
+    pub fn is_builtin(&self) -> bool {
+        let (file, _, _, _) = self.location().location();
+        !file.name().is_some()
+    }
+
     /// Get the `Cursor` for this cursor's referent's lexical parent.
     ///
     /// The lexical parent is the parent of the definition. The semantic parent
@@ -1445,6 +1451,9 @@ pub fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
     }
 
     fn print_cursor<S: AsRef<str>>(depth: isize, prefix: S, c: &Cursor) {
+        if c.is_builtin() {
+            return;
+        }
         let prefix = prefix.as_ref();
         print_indent(depth,
                      format!(" {}kind = {}", prefix, kind_to_str(c.kind())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -826,12 +826,7 @@ impl<'ctx> Bindings<'ctx> {
 /// Determines whether the given cursor is in any of the files matched by the
 /// options.
 fn filter_builtins(ctx: &BindgenContext, cursor: &clang::Cursor) -> bool {
-    let (file, _, _, _) = cursor.location().location();
-
-    match file.name() {
-        None => ctx.options().builtins,
-        Some(..) => true,
-    }
+    !cursor.is_builtin() || ctx.options().builtins
 }
 
 /// Parse one `Item` from the Clang cursor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -826,7 +826,7 @@ impl<'ctx> Bindings<'ctx> {
 /// Determines whether the given cursor is in any of the files matched by the
 /// options.
 fn filter_builtins(ctx: &BindgenContext, cursor: &clang::Cursor) -> bool {
-    !cursor.is_builtin() || ctx.options().builtins
+    ctx.options().builtins || !cursor.is_builtin()
 }
 
 /// Parse one `Item` from the Clang cursor.


### PR DESCRIPTION
Resolves issue #476. Moves out logic for checking whether a cursor has a filename (previously used exclusively in private function lib::filter_builtins) into the actual cursor. This code is then used to check whether a cursor is a builtin when dumping the AST.