### PR TITLE
Reintroduce bitfield accessors

### DIFF
--- a/bindgen-integration/cpp/Test.cc
+++ b/bindgen-integration/cpp/Test.cc
@@ -20,3 +20,31 @@ Test::Test(double foo)
   : m_int(0)
   , m_double(foo)
 {}
+
+namespace bitfields {
+
+bool
+First::assert(unsigned char first,
+              unsigned char second,
+              unsigned char third)
+{
+    return three_bits_byte_one == first &&
+        six_bits_byte_two == second &&
+        two_bits_byte_two == third;
+}
+
+bool
+Second::assert(int first, bool second)
+{
+    return thirty_one_bits == first && one_bit == second;
+}
+
+bool
+Third::assert(int first, bool second, ItemKind third)
+{
+    return flags == first &&
+        is_whatever == second &&
+        kind == third;
+}
+
+}

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -20,3 +20,45 @@ typedef Test TypeAlias;
 } // namespace testing
 
 typedef testing::TypeAlias TypeAlias;
+
+namespace bitfields {
+
+struct First {
+    unsigned char three_bits_byte_one : 3;
+    // This starts a new byte, leaving 5 bits unused.
+    unsigned char :0;
+
+    unsigned char six_bits_byte_two : 6;
+    unsigned char two_bits_byte_two : 2;
+
+    /// Returns true if the bitfields match the arguments, false otherwise.
+    bool assert(unsigned char first,
+                unsigned char second,
+                unsigned char third);
+};
+
+struct Second {
+    int thirty_one_bits : 31;
+    bool one_bit : 1;
+
+    /// Returns true if the bitfields match the arguments, false otherwise.
+    bool assert(int first,
+                bool second);
+};
+
+enum ItemKind {
+    ITEM_KIND_UNO,
+    ITEM_KIND_DOS,
+    ITEM_KIND_TRES,
+};
+
+struct Third {
+    int flags : 28;
+    bool is_whatever : 1;
+    ItemKind kind : 3;
+
+    /// Returns true if the bitfields match the arguments, false otherwise.
+    bool assert(int first, bool second, ItemKind third);
+};
+
+} // namespace bitfields

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -1,9 +1,12 @@
+#![allow(warnings)]
+
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/test.rs"));
 }
 
 use std::ffi::CStr;
 use std::os::raw::c_int;
+use std::mem;
 
 #[test]
 fn test_static_array() {
@@ -46,4 +49,55 @@ fn test_overload() {
     let test = unsafe { bindings::Test::new1(5.0) };
     assert_eq!(test.m_int, 0);
     assert_eq!(test.m_double, 5.0);
+}
+
+#[test]
+fn test_bitfields_first() {
+    let mut first: bindings::bitfields::First = unsafe {
+        mem::zeroed()
+    };
+    assert!(unsafe {
+        first.assert(0, 0, 0)
+    });
+    first.set_three_bits_byte_one(2);
+    first.set_six_bits_byte_two(42);
+    first.set_two_bits_byte_two(1);
+    assert!(unsafe {
+        first.assert(2, 42, 1)
+    });
+}
+
+#[test]
+fn test_bitfields_second() {
+    let mut second: bindings::bitfields::Second = unsafe {
+        mem::zeroed()
+    };
+    assert!(unsafe {
+        second.assert(0, false)
+    });
+    second.set_thirty_one_bits(1337);
+    second.set_one_bit(true);
+    assert!(unsafe {
+        second.assert(1337, true)
+    });
+}
+
+#[test]
+fn test_bitfields_third() {
+    let mut third: bindings::bitfields::Third = unsafe {
+        mem::zeroed()
+    };
+    assert!(unsafe {
+        third.assert(0,
+                     false,
+                     bindings::bitfields::ItemKind::ITEM_KIND_UNO)
+    });
+    third.set_flags(12345);
+    third.set_is_whatever(true);
+    third.set_kind(bindings::bitfields::ItemKind::ITEM_KIND_TRES);
+    assert!(unsafe {
+        third.assert(12345,
+                     true,
+                     bindings::bitfields::ItemKind::ITEM_KIND_TRES)
+    });
 }

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -30,6 +30,188 @@ fn bindgen_test_layout_A() {
 impl Clone for A {
     fn clone(&self) -> Self { *self }
 }
+impl A {
+    #[inline]
+    pub fn b1(&self) -> ::std::os::raw::c_uint {
+        let mask = 1usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 1usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b2(&self) -> ::std::os::raw::c_uint {
+        let mask = 2usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 2usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b3(&self) -> ::std::os::raw::c_uint {
+        let mask = 4usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 2usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b3(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 4usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 2usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b4(&self) -> ::std::os::raw::c_uint {
+        let mask = 8usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 3usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b4(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 8usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 3usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b5(&self) -> ::std::os::raw::c_uint {
+        let mask = 16usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 4usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b5(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 16usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 4usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b6(&self) -> ::std::os::raw::c_uint {
+        let mask = 32usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 5usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b6(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 32usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 5usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b7(&self) -> ::std::os::raw::c_uint {
+        let mask = 64usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 6usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b7(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 64usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 6usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b8(&self) -> ::std::os::raw::c_uint {
+        let mask = 128usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 7usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b8(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 128usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 7usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b9(&self) -> ::std::os::raw::c_uint {
+        let mask = 256usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 8usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b9(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 256usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 8usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b10(&self) -> ::std::os::raw::c_uint {
+        let mask = 512usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 9usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b10(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 512usize as u16;
+        let val = val as u32 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 9usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
 pub struct B {
@@ -45,6 +227,44 @@ fn bindgen_test_layout_B() {
 }
 impl Clone for B {
     fn clone(&self) -> Self { *self }
+}
+impl B {
+    #[inline]
+    pub fn foo(&self) -> ::std::os::raw::c_uint {
+        let mask = 2147483647usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_foo(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 2147483647usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn bar(&self) -> ::std::os::raw::c_uchar {
+        let mask = 2147483648usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 31usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
+        let mask = 2147483648usize as u32;
+        let val = val as u8 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 31usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
@@ -72,6 +292,44 @@ fn bindgen_test_layout_C() {
 impl Clone for C {
     fn clone(&self) -> Self { *self }
 }
+impl C {
+    #[inline]
+    pub fn b1(&self) -> ::std::os::raw::c_uint {
+        let mask = 1usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 1usize as u8;
+        let val = val as u32 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b2(&self) -> ::std::os::raw::c_uint {
+        let mask = 2usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 2usize as u8;
+        let val = val as u32 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
 pub struct Date1 {
@@ -88,6 +346,80 @@ fn bindgen_test_layout_Date1() {
 }
 impl Clone for Date1 {
     fn clone(&self) -> Self { *self }
+}
+impl Date1 {
+    #[inline]
+    pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
+        let mask = 7usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 7usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
+        let mask = 504usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 3usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 504usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 3usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
+        let mask = 15872usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 9usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 15872usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 9usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn nYear(&self) -> ::std::os::raw::c_ushort {
+        let mask = 255usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 255usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
@@ -111,4 +443,78 @@ fn bindgen_test_layout_Date2() {
 }
 impl Clone for Date2 {
     fn clone(&self) -> Self { *self }
+}
+impl Date2 {
+    #[inline]
+    pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
+        let mask = 7usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 7usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
+        let mask = 504usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 3usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 504usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 3usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
+        let mask = 15872usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 9usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 15872usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 9usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn nYear(&self) -> ::std::os::raw::c_ushort {
+        let mask = 255usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 255usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
 }

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -23,3 +23,41 @@ fn bindgen_test_layout_mach_msg_type_descriptor_t() {
 impl Clone for mach_msg_type_descriptor_t {
     fn clone(&self) -> Self { *self }
 }
+impl mach_msg_type_descriptor_t {
+    #[inline]
+    pub fn pad3(&self) -> ::std::os::raw::c_uint {
+        let mask = 16777215usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_pad3(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 16777215usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn type_(&self) -> ::std::os::raw::c_uint {
+        let mask = 4278190080usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 24usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_type(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 4278190080usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 24usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -129,6 +129,44 @@ impl Clone for jsval_layout__bindgen_ty_1 {
 impl Default for jsval_layout__bindgen_ty_1 {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
+impl jsval_layout__bindgen_ty_1 {
+    #[inline]
+    pub fn payload47(&self) -> u64 {
+        let mask = 140737488355327usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_payload47(&mut self, val: u64) {
+        let mask = 140737488355327usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn tag(&self) -> JSValueTag {
+        let mask = 18446603336221196288usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 47usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_tag(&mut self, val: JSValueTag) {
+        let mask = 18446603336221196288usize as u64;
+        let val = val as u32 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 47usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
 pub struct jsval_layout__bindgen_ty_2 {

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -89,3 +89,59 @@ fn bindgen_test_layout_rte_eth_link() {
 impl Clone for rte_eth_link {
     fn clone(&self) -> Self { *self }
 }
+impl rte_eth_link {
+    #[inline]
+    pub fn link_duplex(&self) -> u16 {
+        let mask = 1usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_link_duplex(&mut self, val: u16) {
+        let mask = 1usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn link_autoneg(&self) -> u16 {
+        let mask = 2usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_link_autoneg(&mut self, val: u16) {
+        let mask = 2usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn link_status(&self) -> u16 {
+        let mask = 4usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 2usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_link_status(&mut self, val: u16) {
+        let mask = 4usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 2usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -118,6 +118,170 @@ impl Clone for rte_eth_rxmode {
 impl Default for rte_eth_rxmode {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
+impl rte_eth_rxmode {
+    #[inline]
+    pub fn header_split(&self) -> u16 {
+        let mask = 1usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_header_split(&mut self, val: u16) {
+        let mask = 1usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_ip_checksum(&self) -> u16 {
+        let mask = 2usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_hw_ip_checksum(&mut self, val: u16) {
+        let mask = 2usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_vlan_filter(&self) -> u16 {
+        let mask = 4usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 2usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_hw_vlan_filter(&mut self, val: u16) {
+        let mask = 4usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 2usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_vlan_strip(&self) -> u16 {
+        let mask = 8usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 3usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_hw_vlan_strip(&mut self, val: u16) {
+        let mask = 8usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 3usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_vlan_extend(&self) -> u16 {
+        let mask = 16usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 4usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_hw_vlan_extend(&mut self, val: u16) {
+        let mask = 16usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 4usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn jumbo_frame(&self) -> u16 {
+        let mask = 32usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 5usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_jumbo_frame(&mut self, val: u16) {
+        let mask = 32usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 5usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_strip_crc(&self) -> u16 {
+        let mask = 64usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 6usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_hw_strip_crc(&mut self, val: u16) {
+        let mask = 64usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 6usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn enable_scatter(&self) -> u16 {
+        let mask = 128usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 7usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_enable_scatter(&mut self, val: u16) {
+        let mask = 128usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 7usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn enable_lro(&self) -> u16 {
+        let mask = 256usize as u16;
+        let field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 8usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_enable_lro(&mut self, val: u16) {
+        let mask = 256usize as u16;
+        let val = val as u16 as u16;
+        let mut field_val: u16 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 8usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}
 #[repr(u32)]
 /**
  * A set of values to identify what method is to be used to transmit
@@ -164,6 +328,62 @@ impl Clone for rte_eth_txmode {
 }
 impl Default for rte_eth_txmode {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+impl rte_eth_txmode {
+    #[inline]
+    pub fn hw_vlan_reject_tagged(&self) -> u8 {
+        let mask = 1usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_hw_vlan_reject_tagged(&mut self, val: u8) {
+        let mask = 1usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_vlan_reject_untagged(&self) -> u8 {
+        let mask = 2usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_hw_vlan_reject_untagged(&mut self, val: u8) {
+        let mask = 2usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn hw_vlan_insert_pvid(&self) -> u8 {
+        let mask = 4usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 2usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_hw_vlan_insert_pvid(&mut self, val: u8) {
+        let mask = 4usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 2usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
 }
 /**
  * A structure used to configure the Receive Side Scaling (RSS) feature

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -175,6 +175,134 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2__bindgen_ty_1() {
 impl Clone for rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
+impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
+    #[inline]
+    pub fn l2_type(&self) -> u32 {
+        let mask = 15usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_l2_type(&mut self, val: u32) {
+        let mask = 15usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn l3_type(&self) -> u32 {
+        let mask = 240usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 4usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_l3_type(&mut self, val: u32) {
+        let mask = 240usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 4usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn l4_type(&self) -> u32 {
+        let mask = 3840usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 8usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_l4_type(&mut self, val: u32) {
+        let mask = 3840usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 8usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn tun_type(&self) -> u32 {
+        let mask = 61440usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 12usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_tun_type(&mut self, val: u32) {
+        let mask = 61440usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 12usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn inner_l2_type(&self) -> u32 {
+        let mask = 983040usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 16usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_inner_l2_type(&mut self, val: u32) {
+        let mask = 983040usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 16usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn inner_l3_type(&self) -> u32 {
+        let mask = 15728640usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 20usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_inner_l3_type(&mut self, val: u32) {
+        let mask = 15728640usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 20usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn inner_l4_type(&self) -> u32 {
+        let mask = 251658240usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 24usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_inner_l4_type(&mut self, val: u32) {
+        let mask = 251658240usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 24usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     assert_eq!(::std::mem::size_of::<rte_mbuf__bindgen_ty_2>() , 4usize ,
@@ -424,6 +552,116 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5__bindgen_ty_1() {
 }
 impl Clone for rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
+}
+impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
+    #[inline]
+    pub fn l2_len(&self) -> u64 {
+        let mask = 127usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_l2_len(&mut self, val: u64) {
+        let mask = 127usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn l3_len(&self) -> u64 {
+        let mask = 65408usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 7usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_l3_len(&mut self, val: u64) {
+        let mask = 65408usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 7usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn l4_len(&self) -> u64 {
+        let mask = 16711680usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 16usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_l4_len(&mut self, val: u64) {
+        let mask = 16711680usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 16usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn tso_segsz(&self) -> u64 {
+        let mask = 1099494850560usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 24usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_tso_segsz(&mut self, val: u64) {
+        let mask = 1099494850560usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 24usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn outer_l3_len(&self) -> u64 {
+        let mask = 561850441793536usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 40usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_outer_l3_len(&mut self, val: u64) {
+        let mask = 561850441793536usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 40usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn outer_l2_len(&self) -> u64 {
+        let mask = 71494644084506624usize as u64;
+        let field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 49usize;
+        unsafe { ::std::mem::transmute(val as u64) }
+    }
+    #[inline]
+    pub fn set_outer_l2_len(&mut self, val: u64) {
+        let mask = 71494644084506624usize as u64;
+        let val = val as u64 as u64;
+        let mut field_val: u64 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 49usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -20,3 +20,41 @@ fn bindgen_test_layout_C() {
 impl Clone for C {
     fn clone(&self) -> Self { *self }
 }
+impl C {
+    #[inline]
+    pub fn a(&self) -> bool {
+        let mask = 1usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_a(&mut self, val: bool) {
+        let mask = 1usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b(&self) -> bool {
+        let mask = 254usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: bool) {
+        let mask = 254usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -27,3 +27,113 @@ fn bindgen_test_layout_bitfield() {
 impl Clone for bitfield {
     fn clone(&self) -> Self { *self }
 }
+impl bitfield {
+    #[inline]
+    pub fn a(&self) -> ::std::os::raw::c_ushort {
+        let mask = 1usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 1usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn b(&self) -> ::std::os::raw::c_ushort {
+        let mask = 2usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 1usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 2usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 1usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn c(&self) -> ::std::os::raw::c_ushort {
+        let mask = 4usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 2usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 4usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 2usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn d(&self) -> ::std::os::raw::c_ushort {
+        let mask = 192usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 6usize;
+        unsafe { ::std::mem::transmute(val as u16) }
+    }
+    #[inline]
+    pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
+        let mask = 192usize as u8;
+        let val = val as u16 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 6usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn f(&self) -> ::std::os::raw::c_uint {
+        let mask = 3usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_f(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 3usize as u8;
+        let val = val as u32 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn g(&self) -> ::std::os::raw::c_uint {
+        let mask = 4294967295usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_3) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_g(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 4294967295usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_3) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_3 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -51,6 +51,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self { *self }
 }
+impl foo__bindgen_ty_1 {
+    #[inline]
+    pub fn b(&self) -> ::std::os::raw::c_int {
+        let mask = 127usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
+        let mask = 127usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn c(&self) -> ::std::os::raw::c_int {
+        let mask = 4294967168usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 7usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
+        let mask = 4294967168usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 7usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}
 #[test]
 fn bindgen_test_layout_foo() {
     assert_eq!(::std::mem::size_of::<foo>() , 4usize , concat ! (

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -103,3 +103,131 @@ impl Clone for Weird {
 impl Default for Weird {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
+impl Weird {
+    #[inline]
+    pub fn bitTest(&self) -> ::std::os::raw::c_uint {
+        let mask = 65535usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_bitTest(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 65535usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn bitTest2(&self) -> ::std::os::raw::c_uint {
+        let mask = 2147418112usize as u32;
+        let field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        let val = (field_val & mask) >> 16usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_bitTest2(&mut self, val: ::std::os::raw::c_uint) {
+        let mask = 2147418112usize as u32;
+        let val = val as u32 as u32;
+        let mut field_val: u32 =
+            unsafe { ::std::mem::transmute(self._bitfield_1) };
+        field_val &= !mask;
+        field_val |= (val << 16usize) & mask;
+        self._bitfield_1 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn mFillOpacitySource(&self) -> nsStyleSVGOpacitySource {
+        let mask = 7usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_mFillOpacitySource(&mut self, val: nsStyleSVGOpacitySource) {
+        let mask = 7usize as u8;
+        let val = val as u32 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn mStrokeOpacitySource(&self) -> nsStyleSVGOpacitySource {
+        let mask = 56usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 3usize;
+        unsafe { ::std::mem::transmute(val as u32) }
+    }
+    #[inline]
+    pub fn set_mStrokeOpacitySource(&mut self, val: nsStyleSVGOpacitySource) {
+        let mask = 56usize as u8;
+        let val = val as u32 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 3usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn mStrokeDasharrayFromObject(&self) -> bool {
+        let mask = 64usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 6usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_mStrokeDasharrayFromObject(&mut self, val: bool) {
+        let mask = 64usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 6usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn mStrokeDashoffsetFromObject(&self) -> bool {
+        let mask = 128usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        let val = (field_val & mask) >> 7usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_mStrokeDashoffsetFromObject(&mut self, val: bool) {
+        let mask = 128usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_2) };
+        field_val &= !mask;
+        field_val |= (val << 7usize) & mask;
+        self._bitfield_2 = unsafe { ::std::mem::transmute(field_val) };
+    }
+    #[inline]
+    pub fn mStrokeWidthFromObject(&self) -> bool {
+        let mask = 1usize as u8;
+        let field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_3) };
+        let val = (field_val & mask) >> 0usize;
+        unsafe { ::std::mem::transmute(val as u8) }
+    }
+    #[inline]
+    pub fn set_mStrokeWidthFromObject(&mut self, val: bool) {
+        let mask = 1usize as u8;
+        let val = val as u8 as u8;
+        let mut field_val: u8 =
+            unsafe { ::std::mem::transmute(self._bitfield_3) };
+        field_val &= !mask;
+        field_val |= (val << 0usize) & mask;
+        self._bitfield_3 = unsafe { ::std::mem::transmute(field_val) };
+    }
+}


### PR DESCRIPTION
This commit reintroduces accessor methods for bitfields in the generated
bindings.

Fixes #519 

r? @emilio 