### PR TITLE
Run tests with more versions of libclang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,19 @@ rust:
   - stable
 
 env:
-  - CARGO_TARGET_DIR=/tmp/bindgen LLVM_VERSION=3.8 BINDGEN_FEATURES=testing_only_llvm_stable
-  - CARGO_TARGET_DIR=/tmp/bindgen LLVM_VERSION=3.9 BINDGEN_FEATURES=
+  global:
+    - CARGO_TARGET_DIR=/tmp/bindgen
+  matrix:
+    - LLVM_VERSION=3.7.1 BINDGEN_FEATURES=testing_only_llvm_stable
+    - LLVM_VERSION=3.8.1 BINDGEN_FEATURES=testing_only_llvm_stable
+    - LLVM_VERSION=3.9.0 BINDGEN_FEATURES=
+    - LLVM_VERSION=4.0.0 BINDGEN_FEATURES=
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: LLVM_VERSION=4.0.0 BINDGEN_FEATURES=
+    - env: LLVM_VERSION=3.7.1 BINDGEN_FEATURES=testing_only_llvm_stable
 
 cache:
   directories:

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,4 +1,4 @@
-set -e
+set -ex
 pushd ~
 
 # Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)
@@ -6,16 +6,8 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     rvm get head || true
 fi
 
-function llvm_version_triple() {
-    if [ "$1" == "3.8" ]; then
-        echo "3.8.0"
-    elif [ "$1" == "3.9" ]; then
-        echo "3.9.0"
-    fi
-}
-
 function llvm_download() {
-    export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
+    export LLVM_VERSION_TRIPLE="${LLVM_VERSION}"
     export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-x86_64-$1
 
     wget http://llvm.org/releases/${LLVM_VERSION_TRIPLE}/${LLVM}.tar.xz


### PR DESCRIPTION
First, update our existing 3.8.X and 3.9.X libclang testing versions to their latest point releases. Second, add testing on the latest 3.7.X release and the latest 4.0.X release.

r? @emilio 