### PR TITLE
Make vtables non-zero-size to fix a rustc warning.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -706,11 +706,7 @@ impl<'a> CodeGenerator for Vtable<'a> {
         assert_eq!(item.id(), self.item_id);
         // For now, generate an empty struct, later we should generate function
         // pointers and whatnot.
-        let mut attributes = vec![attributes::repr("C")];
-
-        if ctx.options().derive_default {
-            attributes.push(attributes::derives(&["Default"]))
-        }
+        let attributes = vec![attributes::repr("C")];
 
         let vtable = aster::AstBuilder::new()
             .item()

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -712,7 +712,9 @@ impl<'a> CodeGenerator for Vtable<'a> {
             .item()
             .pub_()
             .with_attrs(attributes)
-            .struct_(self.canonical_name(ctx))
+            .tuple_struct(self.canonical_name(ctx))
+            .field()
+            .build_ty(helpers::ast_ty::raw_type(ctx, "c_void"))
             .build();
         result.push(vtable);
     }

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -10,7 +10,6 @@ pub const whatever_else: _bindgen_ty_1 = _bindgen_ty_1::whatever_else;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum _bindgen_ty_1 { match_ = 0, whatever_else = 1, }
 #[repr(C)]
-#[derive(Default)]
 pub struct C__bindgen_vtable {
 }
 #[repr(C)]

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -10,8 +10,7 @@ pub const whatever_else: _bindgen_ty_1 = _bindgen_ty_1::whatever_else;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum _bindgen_ty_1 { match_ = 0, whatever_else = 1, }
 #[repr(C)]
-pub struct C__bindgen_vtable {
-}
+pub struct C__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct C {

--- a/tests/expectations/tests/nested_vtable.rs
+++ b/tests/expectations/tests/nested_vtable.rs
@@ -5,8 +5,7 @@
 
 
 #[repr(C)]
-pub struct nsISupports__bindgen_vtable {
-}
+pub struct nsISupports__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsISupports {

--- a/tests/expectations/tests/nested_vtable.rs
+++ b/tests/expectations/tests/nested_vtable.rs
@@ -5,7 +5,6 @@
 
 
 #[repr(C)]
-#[derive(Default)]
 pub struct nsISupports__bindgen_vtable {
 }
 #[repr(C)]

--- a/tests/expectations/tests/ref_argument_array.rs
+++ b/tests/expectations/tests/ref_argument_array.rs
@@ -6,7 +6,6 @@
 
 pub const NSID_LENGTH: ::std::os::raw::c_uint = 10;
 #[repr(C)]
-#[derive(Default)]
 pub struct nsID__bindgen_vtable {
 }
 #[repr(C)]

--- a/tests/expectations/tests/ref_argument_array.rs
+++ b/tests/expectations/tests/ref_argument_array.rs
@@ -6,8 +6,7 @@
 
 pub const NSID_LENGTH: ::std::os::raw::c_uint = 10;
 #[repr(C)]
-pub struct nsID__bindgen_vtable {
-}
+pub struct nsID__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsID {

--- a/tests/expectations/tests/virtual_dtor.rs
+++ b/tests/expectations/tests/virtual_dtor.rs
@@ -5,8 +5,7 @@
 
 
 #[repr(C)]
-pub struct nsSlots__bindgen_vtable {
-}
+pub struct nsSlots__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsSlots {

--- a/tests/expectations/tests/virtual_dtor.rs
+++ b/tests/expectations/tests/virtual_dtor.rs
@@ -5,7 +5,6 @@
 
 
 #[repr(C)]
-#[derive(Default)]
 pub struct nsSlots__bindgen_vtable {
 }
 #[repr(C)]

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -25,8 +25,7 @@ impl Clone for A {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct B__bindgen_vtable {
-}
+pub struct B__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct B {
@@ -52,8 +51,7 @@ impl Default for B {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
-pub struct C__bindgen_vtable {
-}
+pub struct C__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct C {

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -25,7 +25,6 @@ impl Clone for A {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-#[derive(Default)]
 pub struct B__bindgen_vtable {
 }
 #[repr(C)]
@@ -53,7 +52,6 @@ impl Default for B {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
-#[derive(Default)]
 pub struct C__bindgen_vtable {
 }
 #[repr(C)]

--- a/tests/expectations/tests/virtual_overloaded.rs
+++ b/tests/expectations/tests/virtual_overloaded.rs
@@ -5,8 +5,7 @@
 
 
 #[repr(C)]
-pub struct C__bindgen_vtable {
-}
+pub struct C__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct C {

--- a/tests/expectations/tests/virtual_overloaded.rs
+++ b/tests/expectations/tests/virtual_overloaded.rs
@@ -5,7 +5,6 @@
 
 
 #[repr(C)]
-#[derive(Default)]
 pub struct C__bindgen_vtable {
 }
 #[repr(C)]

--- a/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/tests/expectations/tests/vtable_recursive_sig.rs
@@ -23,8 +23,7 @@ impl Default for Derived {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
-pub struct Base__bindgen_vtable {
-}
+pub struct Base__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct Base {

--- a/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/tests/expectations/tests/vtable_recursive_sig.rs
@@ -23,7 +23,6 @@ impl Default for Derived {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
-#[derive(Default)]
 pub struct Base__bindgen_vtable {
 }
 #[repr(C)]


### PR DESCRIPTION
```
warning: found non-foreign-function-safe member in struct marked #[repr(C)]: found zero-size struct in foreign module, consider adding a member to this struct
```

Emilio said on IRC:
> the empty vtable means that we don't care of figuring out the proper vtable layout, so we create an empty struct

Sounds like all that matters is to have a pointer, we don’t look at the data behind it. Using `c_void` seems appropriate, then.