### PR TITLE
clang: Fix most of the clang 5.0 regressions in our tests.

### DIFF
--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -429,12 +429,7 @@ impl Type {
     /// Checks whether the name looks like an identifier,
     /// i.e. is alphanumeric (including '_') and does not start with a digit.
     pub fn is_valid_identifier(name: &str) -> bool {
-        let mut chars = name.chars();
-        let first_valid = chars.next()
-            .map(|c| c.is_alphabetic() || c == '_')
-            .unwrap_or(false);
-
-        first_valid && chars.all(|c| c.is_alphanumeric() || c == '_')
+        clang::is_valid_identifier(name)
     }
 
     /// See safe_canonical_type.

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -13,34 +13,29 @@ pub mod root {
         use self::super::super::root;
         #[repr(C)]
         #[derive(Debug, Default, Copy)]
-        pub struct _bindgen_ty_1 {
+        pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
         #[test]
-        fn bindgen_test_layout__bindgen_ty_1() {
-            assert_eq!(::std::mem::size_of::<_bindgen_ty_1>() , 4usize ,
-                       concat ! ( "Size of: " , stringify ! ( _bindgen_ty_1 )
+        fn bindgen_test_layout_typedef_struct() {
+            assert_eq!(::std::mem::size_of::<typedef_struct>() , 4usize ,
+                       concat ! ( "Size of: " , stringify ! ( typedef_struct )
                        ));
-            assert_eq! (::std::mem::align_of::<_bindgen_ty_1>() , 4usize ,
+            assert_eq! (::std::mem::align_of::<typedef_struct>() , 4usize ,
                         concat ! (
-                        "Alignment of " , stringify ! ( _bindgen_ty_1 ) ));
+                        "Alignment of " , stringify ! ( typedef_struct ) ));
             assert_eq! (unsafe {
-                        & ( * ( 0 as * const _bindgen_ty_1 ) ) . foo as *
+                        & ( * ( 0 as * const typedef_struct ) ) . foo as *
                         const _ as usize } , 0usize , concat ! (
-                        "Alignment of field: " , stringify ! ( _bindgen_ty_1 )
-                        , "::" , stringify ! ( foo ) ));
+                        "Alignment of field: " , stringify ! ( typedef_struct
+                        ) , "::" , stringify ! ( foo ) ));
         }
-        impl Clone for _bindgen_ty_1 {
+        impl Clone for typedef_struct {
             fn clone(&self) -> Self { *self }
         }
-        pub type typedef_struct = root::whatever::_bindgen_ty_1;
-        pub const whatever_BAR: root::whatever::_bindgen_ty_2 =
-            _bindgen_ty_2::BAR;
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub enum _bindgen_ty_2 { BAR = 1, }
-        pub use self::super::super::root::whatever::_bindgen_ty_2 as
-                typedef_enum;
+        pub enum typedef_enum { BAR = 1, }
     }
     pub mod _bindgen_mod_id_12 {
         #[allow(unused_imports)]


### PR DESCRIPTION
Still a lot to be sorted out though.