### PR TITLE
#571: Allow ast_dump to print builtins; filter builtins locally

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -1482,9 +1482,6 @@ pub fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
     }
 
     fn print_cursor<S: AsRef<str>>(depth: isize, prefix: S, c: &Cursor) {
-        if c.is_builtin() {
-            return;
-        }
         let prefix = prefix.as_ref();
         print_indent(depth,
                      format!(" {}kind = {}", prefix, kind_to_str(c.kind())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -896,8 +896,17 @@ fn parse(context: &mut BindgenContext) -> Result<(), ()> {
     }
 
     let cursor = context.translation_unit().cursor();
+
     if context.options().emit_ast {
-        cursor.visit(|cur| clang::ast_dump(&cur, 0));
+
+        fn dump_if_not_builtin(cur: &clang::Cursor) -> CXChildVisitResult {
+            if !cur.is_builtin() {
+                clang::ast_dump(&cur, 0)
+            } else {
+                CXChildVisit_Continue
+            }
+        }
+        cursor.visit(|cur| dump_if_not_builtin(&cur));
     }
 
     let root = context.root_module();


### PR DESCRIPTION
This should resolve #571. As discussed with @fitzgen I have moved the builtin-filtering out of `ast_dump` itself; this logic now happens at the point of call in `src/lib.rs`