### PR TITLE
Treat char as c_char

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -1090,38 +1090,10 @@ impl<'ctx> BindgenContext<'ctx> {
             CXType_Bool => TypeKind::Int(IntKind::Bool),
             CXType_Int => TypeKind::Int(IntKind::Int),
             CXType_UInt => TypeKind::Int(IntKind::UInt),
-            CXType_SChar | CXType_Char_S |
-            CXType_UChar | CXType_Char_U => {
-                let spelling = ty.spelling();
-
-                debug_assert!(spelling.contains("char"),
-                              "This is the canonical type, so no aliases or \
-                               typedefs!");
-
-                let signed = match ty.kind() {
-                    CXType_SChar | CXType_Char_S => true,
-                    _ => false,
-                };
-
-                // Clang only gives us the signedness of the target platform.
-                //
-                // Match the spelling for common cases we can handle
-                // cross-platform.
-                match &*spelling {
-                    "char" | "const char" => {
-                        TypeKind::Int(IntKind::Char {
-                            is_signed: signed,
-                        })
-                    },
-                    _ => {
-                        if signed {
-                            TypeKind::Int(IntKind::SChar)
-                        } else {
-                            TypeKind::Int(IntKind::UChar)
-                        }
-                    },
-                }
-            }
+            CXType_Char_S => TypeKind::Int(IntKind::Char { is_signed: true }),
+            CXType_Char_U => TypeKind::Int(IntKind::Char { is_signed: false }),
+            CXType_SChar => TypeKind::Int(IntKind::SChar),
+            CXType_UChar => TypeKind::Int(IntKind::UChar),
             CXType_Short => TypeKind::Int(IntKind::Short),
             CXType_UShort => TypeKind::Int(IntKind::UShort),
             CXType_WChar | CXType_Char16 => TypeKind::Int(IntKind::U16),


### PR DESCRIPTION
Per #603.

This still leaves `bindgen` having to make a call as to what to say when asked whether `Char` `is_signed()`.  I've opted just to leave this as `true`, on the grounds that:

* I don't currently understand an example where it matters
* I suspect that if there are cases where it matters, then it shouldn't!
  * Because by definition, use of unadorned `char` in the original header says that it doesn't care about signedness
* (signed is the common case, so that's a more sensible guess than unsigned)