### PR TITLE
Fall back to opaque types rather than panicking on parse failure

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -424,7 +424,9 @@ impl<'ctx> BindgenContext<'ctx> {
         for (id, ty, loc, parent_id) in typerefs {
             let _resolved = {
                 let resolved = Item::from_ty(&ty, loc, parent_id, self)
-                    .expect("What happened?");
+                    .unwrap_or_else(|_| {
+                        Item::new_opaque_type(self.next_item_id(), &ty, self)
+                    });
                 let mut item = self.items.get_mut(&id).unwrap();
 
                 *item.kind_mut().as_type_mut().unwrap().kind_mut() =

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -425,6 +425,8 @@ impl<'ctx> BindgenContext<'ctx> {
             let _resolved = {
                 let resolved = Item::from_ty(&ty, loc, parent_id, self)
                     .unwrap_or_else(|_| {
+                        warn!("Could not resolve type reference, falling back \
+                               to opaque blob");
                         Item::new_opaque_type(self.next_item_id(), &ty, self)
                     });
                 let mut item = self.items.get_mut(&id).unwrap();

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -433,10 +433,11 @@ impl Item {
         }
     }
 
-    fn new_opaque_type(with_id: ItemId,
-                       ty: &clang::Type,
-                       ctx: &mut BindgenContext)
-                       -> ItemId {
+    /// Construct a new opaque item type.
+    pub fn new_opaque_type(with_id: ItemId,
+                           ty: &clang::Type,
+                           ctx: &mut BindgenContext)
+                           -> ItemId {
         let ty = Opaque::from_clang_ty(ty);
         let kind = ItemKind::Type(ty);
         let parent = ctx.root_module();

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -1093,13 +1093,19 @@ impl Type {
                                     name = location.spelling();
                                 }
 
-                                if let Ok(complex) = CompInfo::from_ty(potential_id,
-                                                                       ty,
-                                                                       Some(location),
-                                                                       ctx) {
-                                    TypeKind::Comp(complex)
-                                } else {
-                                    return Ok(ParseResult::New(Opaque::from_clang_ty(ty), None));
+                                let complex = CompInfo::from_ty(potential_id,
+                                                                ty,
+                                                                Some(location),
+                                                                ctx);
+                                match complex {
+                                    Ok(complex) => TypeKind::Comp(complex),
+                                    Err(_) => {
+                                        warn!("Could not create complex type \
+                                               from class template or base \
+                                               specifier, using opaque blob");
+                                        let opaque = Opaque::from_clang_ty(ty);
+                                        return Ok(ParseResult::New(opaque, None));
+                                    }
                                 }
                             }
                             CXCursor_TypeAliasTemplateDecl => {

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -1093,12 +1093,14 @@ impl Type {
                                     name = location.spelling();
                                 }
 
-                                let complex = CompInfo::from_ty(potential_id,
-                                                                ty,
-                                                                Some(location),
-                                                                ctx)
-                                    .expect("C'mon");
-                                TypeKind::Comp(complex)
+                                if let Ok(complex) = CompInfo::from_ty(potential_id,
+                                                                       ty,
+                                                                       Some(location),
+                                                                       ctx) {
+                                    TypeKind::Comp(complex)
+                                } else {
+                                    return Ok(ParseResult::New(Opaque::from_clang_ty(ty), None));
+                                }
                             }
                             CXCursor_TypeAliasTemplateDecl => {
                                 debug!("TypeAliasTemplateDecl");


### PR DESCRIPTION
Getting closer to figuring out some of the other template related issues in clang 4.0, but not quite ready to land them yet. Figure this should probably land in the meantime. This is just a better fallback in the face of the unknown for panics that we've had reports of in the wild, but which I haven't had time to creduce.

r? @emilio 