### PR TITLE
Generalize template instantiation fallibility

### DIFF
--- a/src/ir/template.rs
+++ b/src/ir/template.rs
@@ -121,8 +121,14 @@ impl TemplateInstantiation {
             });
 
         let definition = match definition {
-            None => return None,
             Some(def) => def,
+            None => {
+                if !ty.declaration().is_builtin() {
+                    warn!("Could not find template definition for template \
+                           instantiation");
+                }
+                return None
+            }
         };
 
         let template_definition =

--- a/src/ir/template.rs
+++ b/src/ir/template.rs
@@ -100,10 +100,6 @@ impl TemplateInstantiation {
                     .collect()
             });
 
-        if ty.declaration().is_builtin() {
-            return None;
-        }
-
         let definition = ty.declaration()
             .specialized()
             .or_else(|| {
@@ -122,8 +118,12 @@ impl TemplateInstantiation {
                 });
 
                 template_ref.and_then(|cur| cur.referenced())
-            })
-            .expect("Should have found the template definition one way or another");
+            });
+
+        let definition = match definition {
+            None => return None,
+            Some(def) => def,
+        };
 
         let template_definition =
             Item::from_ty_or_ref(definition.cur_type(), definition, None, ctx);


### PR DESCRIPTION
Return `None` whenever we can't find a template definition, not only when the
template is a builtin.

Hitting this in other tests with libclang 4

r? @emilio or @upsuper 