### PR TITLE
Don't build documentation for the binary, just the lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "bindgen"
 path = "src/main.rs"
+doc = false
 
 [dev-dependencies]
 diff = "0.1"


### PR DESCRIPTION
This enables one to locally do

    $ cargo doc

and get library level documentation. Without the changes, cargo doesn't know whether to build docs for the binary or library, and so instead it gives an error and stops.

r? @emilio 