### PR TITLE
Add Builder::clang_args (plural)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "bindgen"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/servo/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-version = "0.23.0"
+version = "0.23.1"
 build = "build.rs"
 
 exclude = [

--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -32,9 +32,7 @@ fn main() {
         .enable_cxx_namespaces()
         .raw_line("pub use self::root::*;")
         .header("cpp/Test.h")
-        .clang_arg("-x")
-        .clang_arg("c++")
-        .clang_arg("-std=c++11")
+        .clang_args(&["-x", "c++", "-std=c++11"])
         .parse_callbacks(Box::new(MacroCallback {macros: macros.clone()}))
         .generate()
         .expect("Unable to generate bindings");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,6 +555,16 @@ impl Builder {
         self
     }
 
+    /// Add arguments to be passed straight through to clang.
+    pub fn clang_args<I>(mut self, iter: I) -> Builder
+        where I: IntoIterator,
+              I::Item: AsRef<str> {
+        for arg in iter {
+            self = self.clang_arg(arg.as_ref())
+        }
+        self
+    }
+
     /// Make the generated bindings link the given shared library.
     pub fn link<T: Into<String>>(mut self, library: T) -> Builder {
         self.options.links.push((library.into(), LinkType::Default));


### PR DESCRIPTION
Use `AsRef<str>` rather than `Into<String>` because `&&str` (what you get when iterating `&[&str]`) does not implement the latter.