### PR TITLE
ir: Try to get C++ manglings with the appropriate API first.

### DIFF
--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -126,6 +126,12 @@ pub fn cursor_mangling(ctx: &BindgenContext,
         return None;
     }
 
+    if let Ok(mut manglings) = cursor.cxx_manglings() {
+        if let Some(m) = manglings.pop() {
+            return Some(m);
+        }
+    }
+
     let mut mangling = cursor.mangling();
     if mangling.is_empty() {
         return None;


### PR DESCRIPTION
As pointed out in #653, clang 3.8 asserts when trying to mangle a C++
constructor or a destructor.

The following patch tries to use the `clang_Cursor_getCXXManglings` function
first.

This assumes that the last mangling we're interested in is the proper one,
which seems to be true looking at LLVM, and on trunk on my machine.

Fixes #653 