### PR TITLE
Bump the required clang-sys version to 0.15.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ quasi_codegen = "0.32"
 [dependencies]
 cexpr = "0.2"
 cfg-if = "0.1.0"
-clang-sys = { version = "0.15", features = ["runtime", "clang_3_9"] }
+clang-sys = { version = "0.15.2", features = ["runtime", "clang_3_9"] }
 lazy_static = "0.2.1"
 syntex_syntax = "0.58"
 regex = "0.2"


### PR DESCRIPTION
Better fix for #671 for downstream crates.

r? @upsuper or @emilio 