### PR TITLE
Emit `PhantomData<UnsafeCell<T>>` members for all generic parameters

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1465,11 +1465,20 @@ impl CodeGenerator for CompInfo {
         let mut generics = aster::AstBuilder::new().generics();
 
         if let Some(ref params) = used_template_params {
-            for ty in params.iter() {
+            for (idx, ty) in params.iter().enumerate() {
                 let param = ctx.resolve_type(*ty);
                 let name = param.name().unwrap();
                 let ident = ctx.rust_ident(name);
+
                 generics = generics.ty_param_id(ident);
+
+                let prefix = ctx.trait_prefix();
+                let phantom_ty = quote_ty!(
+                    ctx.ext_cx(),
+                    ::$prefix::marker::PhantomData<::$prefix::cell::UnsafeCell<$ident>>);
+                let phantom_field = StructFieldBuilder::named(format!("_phantom_{}", idx))
+                    .build_ty(phantom_ty);
+                fields.push(phantom_field);
             }
         }
 

--- a/tests/expectations/tests/anonymous-template-types.rs
+++ b/tests/expectations/tests/anonymous-template-types.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct Foo<T> {
     pub t_member: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Foo<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -21,6 +22,7 @@ pub struct Bar {
 #[derive(Debug, Copy, Clone)]
 pub struct Quux<V> {
     pub v_member: V,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
 }
 impl <V> Default for Quux<V> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -53,6 +53,7 @@ impl Clone for A_C {
 #[derive(Debug, Copy, Clone)]
 pub struct A_D<T> {
     pub foo: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for A_D<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -115,11 +116,13 @@ impl Clone for D {
 #[derive(Debug, Copy, Clone)]
 pub struct Templated<T> {
     pub member: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Templated_Templated_inner<T> {
     pub member_ptr: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Templated_Templated_inner<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -8,6 +8,7 @@
 #[derive(Debug)]
 pub struct HandleWithDtor<T> {
     pub ptr: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for HandleWithDtor<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/const_tparam.rs
+++ b/tests/expectations/tests/const_tparam.rs
@@ -9,6 +9,7 @@
 pub struct C<T> {
     pub foo: *const T,
     pub bar: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for C<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/default-template-parameter.rs
+++ b/tests/expectations/tests/default-template-parameter.rs
@@ -9,6 +9,8 @@
 pub struct Foo<T, U> {
     pub t: T,
     pub u: U,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <T, U> Default for Foo<T, U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -13,6 +13,7 @@ pub struct Foo {
 #[derive(Debug, Copy, Clone)]
 pub struct RefPtr<T> {
     pub m_inner: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for RefPtr<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/forward-inherit-struct-with-fields.rs
+++ b/tests/expectations/tests/forward-inherit-struct-with-fields.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct Rooted<T> {
     pub _base: js_RootedBase<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Rooted<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -17,6 +18,7 @@ impl <T> Default for Rooted<T> {
 pub struct js_RootedBase<T> {
     pub foo: *mut T,
     pub next: *mut Rooted<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for js_RootedBase<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/inherit_named.rs
+++ b/tests/expectations/tests/inherit_named.rs
@@ -13,6 +13,7 @@ pub struct Wohoo {
 #[derive(Debug, Copy, Clone)]
 pub struct Weeee<T> {
     pub _base: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Weeee<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -43,6 +43,7 @@ impl Clone for A {
 #[derive(Debug, Copy, Clone)]
 pub struct e<c> {
     pub d: RefPtr<c>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<c>>,
 }
 impl <c> Default for e<c> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
+++ b/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct RefPtr<T> {
     pub use_of_t: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for RefPtr<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -16,6 +17,7 @@ impl <T> Default for RefPtr<T> {
 #[derive(Debug, Copy, Clone)]
 pub struct UsesRefPtrWithAliasedTypeParam<U> {
     pub member: RefPtr<UsesRefPtrWithAliasedTypeParam_V<U>>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 pub type UsesRefPtrWithAliasedTypeParam_V<U> = U;
 impl <U> Default for UsesRefPtrWithAliasedTypeParam<U> {

--- a/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
+++ b/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
@@ -9,6 +9,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct HasRefPtr<T> {
     pub refptr_member: RefPtr<HasRefPtr_TypedefOfT<T>>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 pub type HasRefPtr_TypedefOfT<T> = T;
 impl <T> Default for HasRefPtr<T> {

--- a/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
+++ b/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct RefPtr<T> {
     pub a: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for RefPtr<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -16,6 +17,7 @@ impl <T> Default for RefPtr<T> {
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHolder<T> {
     pub a: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for nsMainThreadPtrHolder<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -24,6 +26,7 @@ impl <T> Default for nsMainThreadPtrHolder<T> {
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHandle<T> {
     pub mPtr: RefPtr<nsMainThreadPtrHolder<T>>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for nsMainThreadPtrHandle<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/issue-662-part-2.rs
+++ b/tests/expectations/tests/issue-662-part-2.rs
@@ -9,6 +9,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHolder<T> {
     pub a: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for nsMainThreadPtrHolder<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -17,6 +18,7 @@ impl <T> Default for nsMainThreadPtrHolder<T> {
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHandle<U> {
     pub mPtr: RefPtr<nsMainThreadPtrHolder<U>>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <U> Default for nsMainThreadPtrHandle<U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -69,6 +69,7 @@ pub mod root {
         pub m_c: T,
         pub m_c_ptr: *mut T,
         pub m_c_arr: [T; 10usize],
+        _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     }
     impl <T> Default for C<T> {
         fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -81,6 +82,7 @@ pub mod root {
         #[derive(Debug)]
         pub struct D<T> {
             pub m_c: root::C<T>,
+            _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
         }
         impl <T> Default for D<T> {
             fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/nsStyleAutoArray.rs
+++ b/tests/expectations/tests/nsStyleAutoArray.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct nsTArray<T> {
     pub mBuff: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for nsTArray<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -17,6 +18,7 @@ impl <T> Default for nsTArray<T> {
 pub struct nsStyleAutoArray<T> {
     pub mFirstElement: T,
     pub mOtherElements: nsTArray<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/tests/expectations/tests/replace_template_alias.rs
+++ b/tests/expectations/tests/replace_template_alias.rs
@@ -12,6 +12,7 @@ pub type JS_detail_MaybeWrapped<T> = T;
 #[derive(Debug, Copy, Clone)]
 pub struct JS_Rooted<T> {
     pub ptr: JS_detail_MaybeWrapped<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for JS_Rooted<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/replaces_double.rs
+++ b/tests/expectations/tests/replaces_double.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct Rooted<T> {
     pub ptr: Rooted_MaybeWrapped<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 /**
      * <div rustbindgen replaces="Rooted_MaybeWrapped"></div>

--- a/tests/expectations/tests/template-param-usage-0.rs
+++ b/tests/expectations/tests/template-param-usage-0.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
     pub t: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for UsesTemplateParameter<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-10.rs
+++ b/tests/expectations/tests/template-param-usage-10.rs
@@ -8,6 +8,8 @@
 #[derive(Debug, Copy, Clone)]
 pub struct DoublyIndirectUsage<T, U> {
     pub doubly_indirect: DoublyIndirectUsage_IndirectUsage<T, U>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 pub type DoublyIndirectUsage_Aliased<T> = T;
 pub type DoublyIndirectUsage_Typedefed<U> = U;
@@ -16,6 +18,8 @@ pub type DoublyIndirectUsage_Typedefed<U> = U;
 pub struct DoublyIndirectUsage_IndirectUsage<T, U> {
     pub member: DoublyIndirectUsage_Aliased<T>,
     pub another: DoublyIndirectUsage_Typedefed<U>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <T, U> Default for DoublyIndirectUsage_IndirectUsage<T, U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-12.rs
+++ b/tests/expectations/tests/template-param-usage-12.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct BaseUsesT<T> {
     pub t: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for BaseUsesT<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -17,6 +18,7 @@ impl <T> Default for BaseUsesT<T> {
 pub struct CrtpUsesU<U> {
     pub _base: BaseUsesT<CrtpUsesU<U>>,
     pub usage: U,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <U> Default for CrtpUsesU<U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-13.rs
+++ b/tests/expectations/tests/template-param-usage-13.rs
@@ -14,6 +14,7 @@ pub struct BaseIgnoresT {
 pub struct CrtpUsesU<U> {
     pub _base: BaseIgnoresT,
     pub usage: U,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <U> Default for CrtpUsesU<U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-15.rs
+++ b/tests/expectations/tests/template-param-usage-15.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct BaseUsesT<T> {
     pub usage: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for BaseUsesT<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-2.rs
+++ b/tests/expectations/tests/template-param-usage-2.rs
@@ -8,11 +8,13 @@
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
     pub t: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     pub also: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-3.rs
+++ b/tests/expectations/tests/template-param-usage-3.rs
@@ -8,12 +8,15 @@
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
     pub t: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {
     pub also: T,
     pub more: U,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <T, U> Default for
  UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {

--- a/tests/expectations/tests/template-param-usage-4.rs
+++ b/tests/expectations/tests/template-param-usage-4.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
     pub t: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/tests/expectations/tests/template-param-usage-5.rs
+++ b/tests/expectations/tests/template-param-usage-5.rs
@@ -8,6 +8,7 @@
 #[derive(Debug, Copy, Clone)]
 pub struct IndirectlyUsesTemplateParameter<T> {
     pub aliased: IndirectlyUsesTemplateParameter_Aliased<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 pub type IndirectlyUsesTemplateParameter_Aliased<T> = T;
 impl <T> Default for IndirectlyUsesTemplateParameter<T> {

--- a/tests/expectations/tests/template-param-usage-7.rs
+++ b/tests/expectations/tests/template-param-usage-7.rs
@@ -9,6 +9,8 @@
 pub struct DoesNotUseU<T, V> {
     pub t: T,
     pub v: V,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
 }
 impl <T, V> Default for DoesNotUseU<T, V> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template-param-usage-8.rs
+++ b/tests/expectations/tests/template-param-usage-8.rs
@@ -9,6 +9,8 @@
 pub struct IndirectUsage<T, U> {
     pub member1: IndirectUsage_Typedefed<T>,
     pub member2: IndirectUsage_Aliased<U>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 pub type IndirectUsage_Typedefed<T> = T;
 pub type IndirectUsage_Aliased<U> = U;

--- a/tests/expectations/tests/template-param-usage-9.rs
+++ b/tests/expectations/tests/template-param-usage-9.rs
@@ -16,6 +16,8 @@ pub type DoesNotUse_Typedefed<U> = U;
 pub struct DoesNotUse_IndirectUsage<T, U> {
     pub member: DoesNotUse_Aliased<T>,
     pub another: DoesNotUse_Typedefed<U>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <T, U> Default for DoesNotUse_IndirectUsage<T, U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -10,6 +10,7 @@ pub struct Foo<T> {
     pub m_member: T,
     pub m_member_ptr: *mut T,
     pub m_member_arr: [T; 1usize],
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Foo<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -29,6 +30,7 @@ pub type D_MyFoo = Foo<::std::os::raw::c_int>;
 pub struct D_U<Z> {
     pub m_nested_foo: D_MyFoo,
     pub m_baz: Z,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<Z>>,
 }
 impl <Z> Default for D_U<Z> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -42,6 +44,7 @@ pub struct Rooted<T> {
     pub prev: *mut T,
     pub next: *mut Rooted<*mut ::std::os::raw::c_void>,
     pub ptr: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Rooted<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -73,6 +76,7 @@ impl Default for RootedContainer {
 #[derive(Debug)]
 pub struct WithDtor<T> {
     pub member: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for WithDtor<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -133,6 +137,7 @@ impl Clone for POD {
 #[derive(Debug, Copy, Clone)]
 pub struct NestedReplaced<T> {
     pub buff: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for NestedReplaced<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -141,6 +146,7 @@ impl <T> Default for NestedReplaced<T> {
 #[derive(Debug, Copy, Clone)]
 pub struct NestedBase<T> {
     pub buff: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for NestedBase<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -149,6 +155,7 @@ impl <T> Default for NestedBase<T> {
 #[derive(Debug, Copy, Clone)]
 pub struct Incomplete<T> {
     pub d: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Incomplete<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -159,6 +166,7 @@ pub struct NestedContainer<T> {
     pub c: T,
     pub nested: NestedReplaced<T>,
     pub inc: Incomplete<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for NestedContainer<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -193,6 +201,7 @@ pub struct Templated {
 #[derive(Debug)]
 pub struct ReplacedWithoutDestructor<T> {
     pub buff: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for ReplacedWithoutDestructor<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -201,6 +210,7 @@ impl <T> Default for ReplacedWithoutDestructor<T> {
 #[derive(Debug)]
 pub struct ShouldNotBeCopiable<T> {
     pub m_member: ReplacedWithoutDestructor<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for ShouldNotBeCopiable<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -209,6 +219,7 @@ impl <T> Default for ShouldNotBeCopiable<T> {
 #[derive(Debug)]
 pub struct ShouldNotBeCopiableAsWell<U> {
     pub m_member: ReplacedWithoutDestructorFwd<U>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl <U> Default for ShouldNotBeCopiableAsWell<U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -223,6 +234,7 @@ impl <U> Default for ShouldNotBeCopiableAsWell<U> {
 #[derive(Debug)]
 pub struct ReplacedWithoutDestructorFwd<T> {
     pub buff: *mut T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for ReplacedWithoutDestructorFwd<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template_alias.rs
+++ b/tests/expectations/tests/template_alias.rs
@@ -9,6 +9,7 @@ pub type JS_detail_Wrapped<T> = T;
 #[derive(Debug, Copy, Clone)]
 pub struct JS_Rooted<T> {
     pub ptr: JS_detail_Wrapped<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for JS_Rooted<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template_alias_namespace.rs
+++ b/tests/expectations/tests/template_alias_namespace.rs
@@ -20,6 +20,7 @@ pub mod root {
         #[derive(Debug, Copy, Clone)]
         pub struct Rooted<T> {
             pub ptr: root::JS::detail::Wrapped<T>,
+            _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
         }
         impl <T> Default for Rooted<T> {
             fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/template_typedef_transitive_param.rs
+++ b/tests/expectations/tests/template_typedef_transitive_param.rs
@@ -13,6 +13,7 @@ pub struct Wrapper {
 #[derive(Debug, Copy, Clone)]
 pub struct Wrapper_Wrapped<T> {
     pub t: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Wrapper_Wrapped<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/type_alias_partial_template_especialization.rs
+++ b/tests/expectations/tests/type_alias_partial_template_especialization.rs
@@ -9,6 +9,7 @@ pub type MaybeWrapped<A> = A;
 #[derive(Debug, Copy, Clone)]
 pub struct Rooted<T> {
     pub ptr: MaybeWrapped<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Rooted<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/using.rs
+++ b/tests/expectations/tests/using.rs
@@ -9,6 +9,7 @@
 pub struct Point<T> {
     pub x: T,
     pub y: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for Point<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/what_is_going_on.rs
+++ b/tests/expectations/tests/what_is_going_on.rs
@@ -25,6 +25,7 @@ pub type Float = f32;
 pub struct PointTyped<F> {
     pub x: F,
     pub y: F,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<F>>,
 }
 impl <F> Default for PointTyped<F> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/expectations/tests/whitelist_basic.rs
+++ b/tests/expectations/tests/whitelist_basic.rs
@@ -9,11 +9,13 @@
 pub struct WhitelistMe<T> {
     pub foo: ::std::os::raw::c_int,
     pub bar: WhitelistMe_Inner<T>,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct WhitelistMe_Inner<T> {
     pub bar: T,
+    _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl <T> Default for WhitelistMe_Inner<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }

--- a/tests/stylo_sanity.rs
+++ b/tests/stylo_sanity.rs
@@ -539,7 +539,8 @@ fn sanity_check_can_generate_stylo_bindings() {
 
     println!("");
     println!("");
-    println!("Generated Stylo bindings in: {:?}", now.duration_since(then));
+    println!("Generated Stylo bindings in: {:?}",
+             now.duration_since(then));
     println!("");
     println!("");
 


### PR DESCRIPTION
This makes generated generic structs lifetime invariant, since we cannot know
the C++ type's true variance.

Fixes #506 

Rebased + squashed version of #635; cc @Kowasaki

To resolve the conflicts and rebase and squash, I did essentially these commands:

```
$ git fetch servo
$ git checkout -b Kowasaki-master servo/master
$ git merge --squash --edit Kowasaki/master
$ cargo test
$ cd tests/expectations
$ cargo test
$ cd -
$ git commit --author="Kowasaki"
$ git push fitzgen Kowasaki-master
```

Hopefully that is useful for you in the future :) Thanks for fixing this issue!