### PR TITLE
Bump clang-sys to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -69,7 +69,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clang-sys"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -346,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "393a5f0088efbe41f9d1fcd062f24e83c278608420e62109feb2c8abee07de7d"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum clang-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f4f6aa0c4cfa318cd4d2940afae57e48b94d44d3aced603501df24f3c2a414f"
+"checksum clang-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33d47b0ea88a529a570490efbb79403e416e89864ce8a96bf23e2a0f23d7e9eb"
 "checksum clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f57e9b63057a545ad2ecd773ea61e49422ed1b1d63d74d5da5ecaee55b3396cd"
 "checksum diff 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0a515461b6c8c08419850ced27bc29e86166dcdcde8fbe76f8b1f0589bb49472"
 "checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ quasi_codegen = "0.32"
 [dependencies]
 cexpr = "0.2"
 cfg-if = "0.1.0"
-clang-sys = { version = "0.16.0", features = ["runtime", "clang_3_9"] }
+clang-sys = { version = "0.17.0", features = ["runtime", "clang_3_9"] }
 lazy_static = "0.2.1"
 syntex_syntax = "0.58"
 regex = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,10 +1047,12 @@ impl<'ctx> Bindings<'ctx> {
             if !has_target_arg {
                 // TODO: distinguish C and C++ paths? C++'s should be enough, I
                 // guess.
-                for path in clang.cpp_search_paths.into_iter() {
-                    if let Ok(path) = path.into_os_string().into_string() {
-                        options.clang_args.push("-isystem".to_owned());
-                        options.clang_args.push(path);
+                if let Some(cpp_search_paths) = clang.cpp_search_paths {
+                    for path in cpp_search_paths.into_iter() {
+                        if let Ok(path) = path.into_os_string().into_string() {
+                            options.clang_args.push("-isystem".to_owned());
+                            options.clang_args.push(path);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It turns out that some versions of Clang don't have `#include <...> search starts here:` in their output (KyleMayes/clang-sys#54).

I changed the storage type of the include search paths in `clang-sys` from `Vec<PathBuf>` to `Option<Vec<PathBuf>>` to reflect the possibility that finding and parsing the include search paths might fail.