### PR TITLE
Add other bitwise ops for bitflag enums

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2009,8 +2009,43 @@ impl<'a> EnumBuilder<'a> {
                     }
                 )
                     .unwrap();
-
                 result.push(impl_);
+
+                let impl_ = quote_item!(ctx.ext_cx(),
+                    impl ::$prefix::ops::BitOrAssign for $rust_ty {
+                        #[inline]
+                        fn bitor_assign(&mut self, rhs: $rust_ty) {
+                            self.0 |= rhs.0;
+                        }
+                    }
+                )
+                    .unwrap();
+                result.push(impl_);
+
+                let impl_ = quote_item!(ctx.ext_cx(),
+                    impl ::$prefix::ops::BitAnd<$rust_ty> for $rust_ty {
+                        type Output = Self;
+
+                        #[inline]
+                        fn bitand(self, other: Self) -> Self {
+                            $rust_ty_name(self.0 & other.0)
+                        }
+                    }
+                )
+                    .unwrap();
+                result.push(impl_);
+
+                let impl_ = quote_item!(ctx.ext_cx(),
+                    impl ::$prefix::ops::BitAndAssign for $rust_ty {
+                        #[inline]
+                        fn bitand_assign(&mut self, rhs: $rust_ty) {
+                            self.0 &= rhs.0;
+                        }
+                    }
+                )
+                    .unwrap();
+                result.push(impl_);
+
                 aster
             }
             EnumBuilder::Consts { aster, .. } => aster,

--- a/tests/expectations/tests/bitfield-enum-basic.rs
+++ b/tests/expectations/tests/bitfield-enum-basic.rs
@@ -16,6 +16,22 @@ impl ::std::ops::BitOr<Foo> for Foo {
     #[inline]
     fn bitor(self, other: Self) -> Self { Foo(self.0 | other.0) }
 }
+impl ::std::ops::BitOrAssign for Foo {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Foo) { self.0 |= rhs.0; }
+}
+impl ::std::ops::BitAnd<Foo> for Foo {
+    type
+    Output
+    =
+    Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self { Foo(self.0 & other.0) }
+}
+impl ::std::ops::BitAndAssign for Foo {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Foo) { self.0 &= rhs.0; }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Foo(pub ::std::os::raw::c_int);
@@ -31,6 +47,22 @@ impl ::std::ops::BitOr<Buz> for Buz {
     #[inline]
     fn bitor(self, other: Self) -> Self { Buz(self.0 | other.0) }
 }
+impl ::std::ops::BitOrAssign for Buz {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Buz) { self.0 |= rhs.0; }
+}
+impl ::std::ops::BitAnd<Buz> for Buz {
+    type
+    Output
+    =
+    Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self { Buz(self.0 & other.0) }
+}
+impl ::std::ops::BitAndAssign for Buz {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Buz) { self.0 &= rhs.0; }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Buz(pub ::std::os::raw::c_schar);
@@ -43,6 +75,22 @@ impl ::std::ops::BitOr<_bindgen_ty_1> for _bindgen_ty_1 {
     Self;
     #[inline]
     fn bitor(self, other: Self) -> Self { _bindgen_ty_1(self.0 | other.0) }
+}
+impl ::std::ops::BitOrAssign for _bindgen_ty_1 {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: _bindgen_ty_1) { self.0 |= rhs.0; }
+}
+impl ::std::ops::BitAnd<_bindgen_ty_1> for _bindgen_ty_1 {
+    type
+    Output
+    =
+    Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self { _bindgen_ty_1(self.0 & other.0) }
+}
+impl ::std::ops::BitAndAssign for _bindgen_ty_1 {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: _bindgen_ty_1) { self.0 &= rhs.0; }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -63,6 +111,24 @@ impl ::std::ops::BitOr<Dummy__bindgen_ty_1> for Dummy__bindgen_ty_1 {
     fn bitor(self, other: Self) -> Self {
         Dummy__bindgen_ty_1(self.0 | other.0)
     }
+}
+impl ::std::ops::BitOrAssign for Dummy__bindgen_ty_1 {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Dummy__bindgen_ty_1) { self.0 |= rhs.0; }
+}
+impl ::std::ops::BitAnd<Dummy__bindgen_ty_1> for Dummy__bindgen_ty_1 {
+    type
+    Output
+    =
+    Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        Dummy__bindgen_ty_1(self.0 & other.0)
+    }
+}
+impl ::std::ops::BitAndAssign for Dummy__bindgen_ty_1 {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Dummy__bindgen_ty_1) { self.0 &= rhs.0; }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Currently, bitflag enums only implement `BitOr`. However, it is fairly common to `&` bitflags, requiring the `BitAnd` trait to be implemented as well. I also implemented `BitOrAssign` and `BitAndAssign` in the process.