### PR TITLE
codegen: Reuse the next_child_local_id hack for template instantiations.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -760,8 +760,8 @@ impl CodeGenerator for TemplateInstantiation {
 
             let name = item.canonical_name(ctx);
             let fn_name = format!("__bindgen_test_layout_{}_instantiation_{}",
-                                  name,
-                                  item.id().as_usize());
+                                  name, item.exposed_id(ctx));
+
             let fn_name = ctx.rust_ident_raw(&fn_name);
 
             let prefix = ctx.trait_prefix();

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -370,7 +370,7 @@ pub struct Item {
     /// This item's id.
     id: ItemId,
 
-    /// The item's local id, unique only amongst its siblings.  Only used for
+    /// The item's local id, unique only amongst its siblings. Only used for
     /// anonymous items.
     ///
     /// Lazily initialized in local_id().
@@ -379,7 +379,7 @@ pub struct Item {
     /// case this is an implementation detail.
     local_id: Cell<Option<usize>>,
 
-    /// The next local id to use for a child..
+    /// The next local id to use for a child or template instantiation.
     next_child_local_id: Cell<usize>,
 
     /// A cached copy of the canonical name, as returned by `canonical_name`.
@@ -490,11 +490,21 @@ impl Item {
     pub fn local_id(&self, ctx: &BindgenContext) -> usize {
         if self.local_id.get().is_none() {
             let parent = ctx.resolve_item(self.parent_id);
-            let local_id = parent.next_child_local_id.get();
-            parent.next_child_local_id.set(local_id + 1);
-            self.local_id.set(Some(local_id));
+            self.local_id.set(Some(parent.next_child_local_id()));
         }
         self.local_id.get().unwrap()
+    }
+
+    /// Get an identifier that differentiates a child of this item of other
+    /// related items.
+    ///
+    /// This is currently used for anonymous items, and template instantiation
+    /// tests, in both cases in order to reduce noise when system headers are at
+    /// place.
+    pub fn next_child_local_id(&self) -> usize {
+        let local_id = self.next_child_local_id.get();
+        self.next_child_local_id.set(local_id + 1);
+        local_id
     }
 
     /// Returns whether this item is a top-level item, from the point of view of
@@ -777,13 +787,16 @@ impl Item {
         ctx.rust_mangle(&name).into_owned()
     }
 
-    fn exposed_id(&self, ctx: &BindgenContext) -> String {
+    /// The exposed id that represents an unique id among the siblings of a
+    /// given item.
+    pub fn exposed_id(&self, ctx: &BindgenContext) -> String {
         // Only use local ids for enums, classes, structs and union types.  All
         // other items use their global id.
         let ty_kind = self.kind().as_type().map(|t| t.kind());
         if let Some(ty_kind) = ty_kind {
             match *ty_kind {
                 TypeKind::Comp(..) |
+                TypeKind::TemplateInstantiation(..) |
                 TypeKind::Enum(..) => return self.local_id(ctx).to_string(),
                 _ => {}
             }

--- a/tests/expectations/tests/anon_union.rs
+++ b/tests/expectations/tests/anon_union.rs
@@ -80,7 +80,7 @@ impl Default for ErrorResult {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_TErrorResult_instantiation_21() {
+fn __bindgen_test_layout_TErrorResult_instantiation_1() {
     assert_eq!(::std::mem::size_of::<TErrorResult>() , 24usize , concat ! (
                "Size of template specialization: " , stringify ! (
                TErrorResult ) ));

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -78,7 +78,7 @@ extern "C" {
     pub static mut var: A_B;
 }
 #[test]
-fn __bindgen_test_layout_A_D_instantiation_16() {
+fn __bindgen_test_layout_A_D_instantiation_1() {
     assert_eq!(::std::mem::size_of::<A_D<::std::os::raw::c_int>>() , 4usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -35,7 +35,7 @@ impl Default for WithoutDtor {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_HandleWithDtor_instantiation_10() {
+fn __bindgen_test_layout_HandleWithDtor_instantiation_1() {
     assert_eq!(::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>()
                , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/crtp.rs
+++ b/tests/expectations/tests/crtp.rs
@@ -51,7 +51,7 @@ impl Default for DerivedFromBaseWithDestructor {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Base_instantiation_9() {
+fn __bindgen_test_layout_Base_instantiation_1() {
     assert_eq!(::std::mem::size_of::<Base>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( Base ) ));
     assert_eq!(::std::mem::align_of::<Base>() , 1usize , concat ! (
@@ -59,7 +59,7 @@ fn __bindgen_test_layout_Base_instantiation_9() {
                ));
 }
 #[test]
-fn __bindgen_test_layout_BaseWithDestructor_instantiation_12() {
+fn __bindgen_test_layout_BaseWithDestructor_instantiation_2() {
     assert_eq!(::std::mem::size_of::<BaseWithDestructor>() , 1usize , concat !
                (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/default-template-parameter.rs
+++ b/tests/expectations/tests/default-template-parameter.rs
@@ -16,7 +16,7 @@ impl <T, U> Default for Foo<T, U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Foo_instantiation_6() {
+fn __bindgen_test_layout_Foo_instantiation_1() {
     assert_eq!(::std::mem::size_of::<Foo<bool, ::std::os::raw::c_int>>() ,
                8usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -32,7 +32,7 @@ impl Default for JS_AutoIdVector {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_JS_Base_instantiation_20() {
+fn __bindgen_test_layout_JS_Base_instantiation_2() {
     assert_eq!(::std::mem::size_of::<JS_Base>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( JS_Base )
                ));

--- a/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -51,7 +51,7 @@ impl Default for ServoElementSnapshotTable {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Set_instantiation_13() {
+fn __bindgen_test_layout_Set_instantiation_1() {
     assert_eq!(::std::mem::size_of::<Set>() , 4usize , concat ! (
                "Size of template specialization: " , stringify ! ( Set ) ));
     assert_eq!(::std::mem::align_of::<Set>() , 4usize , concat ! (

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -38,7 +38,7 @@ impl Default for UsesArray {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Array_instantiation_18() {
+fn __bindgen_test_layout_Array_instantiation_1() {
     assert_eq!(::std::mem::size_of::<[u32; 4usize]>() , 16usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 4usize] ) ));

--- a/tests/expectations/tests/partial-specialization-and-inheritance.rs
+++ b/tests/expectations/tests/partial-specialization-and-inheritance.rs
@@ -15,7 +15,7 @@ pub struct Derived {
     pub b: bool,
 }
 #[test]
-fn __bindgen_test_layout__bindgen_ty_id_20_instantiation_14() {
+fn __bindgen_test_layout__bindgen_ty_id_20_instantiation_1() {
     assert_eq!(::std::mem::size_of::<[u32; 2usize]>() , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 2usize] ) ));

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -245,7 +245,7 @@ pub struct TemplateWithVar {
     pub _address: u8,
 }
 #[test]
-fn __bindgen_test_layout_Foo_instantiation_95() {
+fn __bindgen_test_layout_Foo_instantiation_1() {
     assert_eq!(::std::mem::size_of::<Foo<::std::os::raw::c_int>>() , 24usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (
@@ -256,7 +256,7 @@ fn __bindgen_test_layout_Foo_instantiation_95() {
                Foo<::std::os::raw::c_int> ) ));
 }
 #[test]
-fn __bindgen_test_layout_Foo_instantiation_101() {
+fn __bindgen_test_layout_Foo_instantiation_2() {
     assert_eq!(::std::mem::size_of::<Foo<::std::os::raw::c_int>>() , 24usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (
@@ -267,7 +267,7 @@ fn __bindgen_test_layout_Foo_instantiation_101() {
                Foo<::std::os::raw::c_int> ) ));
 }
 #[test]
-fn __bindgen_test_layout_Rooted_instantiation_111() {
+fn __bindgen_test_layout_Rooted_instantiation_3() {
     assert_eq!(::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>() ,
                24usize , concat ! (
                "Size of template specialization: " , stringify ! (
@@ -278,7 +278,7 @@ fn __bindgen_test_layout_Rooted_instantiation_111() {
                Rooted<*mut ::std::os::raw::c_void> ) ));
 }
 #[test]
-fn __bindgen_test_layout_WithDtor_instantiation_123() {
+fn __bindgen_test_layout_WithDtor_instantiation_4() {
     assert_eq!(::std::mem::size_of::<WithDtor<::std::os::raw::c_int>>() ,
                4usize , concat ! (
                "Size of template specialization: " , stringify ! (


### PR DESCRIPTION
This should be good enough, following the pattern of anonymous items, and should
prevent most of the current noise in stylo updates.

Closes #620
Fixes #619