### PR TITLE
Minor version bump to peek up clang-sys updates in stylo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "bindgen"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/servo/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-version = "0.25.0"
+version = "0.25.1"
 build = "build.rs"
 
 exclude = [


### PR DESCRIPTION
This should fix https://bugzilla.mozilla.org/show_bug.cgi?id=1365488

There aren't any breaking changes since 0.25, only new features and fixes for libclang >3.9