### PR TITLE
ir: Add the osx mangling hack to a missing path.

### DIFF
--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -127,7 +127,13 @@ pub fn cursor_mangling(ctx: &BindgenContext,
     }
 
     if let Ok(mut manglings) = cursor.cxx_manglings() {
-        if let Some(m) = manglings.pop() {
+        if let Some(mut m) = manglings.pop() {
+            debug_assert!(!m.is_empty(),
+                          "This API never returns empty strings!");
+            // Se the comment below for why this is nasty.
+            if cfg!(target_os = "macos") {
+                m.remove(0);
+            }
             return Some(m);
         }
     }


### PR DESCRIPTION
This would cause linker errors in rustc on OSX.

I don't think I have a great way to test it until we fix the host == target
assumption though.