### PR TITLE
Fix bitfield generation bug with const function

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1106,19 +1106,16 @@ impl Bitfield {
             quote_tokens!(ctx.ext_cx(), pub fn)
         };
 
+        // Don't use variables or blocks because const function does not allow them.
         quote_item!(
             ctx.ext_cx(),
             impl XxxUnused {
                 #[inline]
                 $fn_prefix $ctor_name($params $param_name : $bitfield_ty)
                                       -> $unit_field_int_ty {
-                    let bitfield_unit_val = $body;
-                    let $param_name = $param_name
-                        as $bitfield_int_ty
-                        as $unit_field_int_ty;
-                    let mask = $mask as $unit_field_int_ty;
-                    let $param_name = ($param_name << $offset) & mask;
-                    bitfield_unit_val | $param_name
+                    ($body | 
+                        (($param_name as $bitfield_int_ty as $unit_field_int_ty) << $offset) & 
+                        ($mask as $unit_field_int_ty)) 
                 }
             }
         ).unwrap()

--- a/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/tests/expectations/tests/bitfield-method-same-name.rs
@@ -55,12 +55,9 @@ impl Foo {
     #[inline]
     pub fn new_bitfield_1(type__bindgen_bitfield: ::std::os::raw::c_char)
      -> u8 {
-        let bitfield_unit_val = { 0 };
-        let type__bindgen_bitfield = type__bindgen_bitfield as u8 as u8;
-        let mask = 7usize as u8;
-        let type__bindgen_bitfield =
-            (type__bindgen_bitfield << 0usize) & mask;
-        bitfield_unit_val | type__bindgen_bitfield
+        ({ 0 } |
+             ((type__bindgen_bitfield as u8 as u8) << 0usize) &
+                 (7usize as u8))
     }
     #[inline]
     pub unsafe fn type_(&mut self) -> ::std::os::raw::c_char {

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -222,122 +222,39 @@ impl A {
                           b8: ::std::os::raw::c_uint,
                           b9: ::std::os::raw::c_uint,
                           b10: ::std::os::raw::c_uint) -> u16 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val =
-                            {
-                                let bitfield_unit_val =
-                                    {
-                                        let bitfield_unit_val =
-                                            {
-                                                let bitfield_unit_val =
-                                                    {
-                                                        let bitfield_unit_val =
-                                                            {
-                                                                let bitfield_unit_val =
-                                                                    {
-                                                                        let bitfield_unit_val =
-                                                                            {
-                                                                                let bitfield_unit_val =
-                                                                                    {
-                                                                                        0
-                                                                                    };
-                                                                                let b1 =
-                                                                                    b1
-                                                                                        as
-                                                                                        u32
-                                                                                        as
-                                                                                        u16;
-                                                                                let mask =
-                                                                                    1usize
-                                                                                        as
-                                                                                        u16;
-                                                                                let b1 =
-                                                                                    (b1
-                                                                                         <<
-                                                                                         0usize)
-                                                                                        &
-                                                                                        mask;
-                                                                                bitfield_unit_val
-                                                                                    |
-                                                                                    b1
-                                                                            };
-                                                                        let b2 =
-                                                                            b2
-                                                                                as
-                                                                                u32
-                                                                                as
-                                                                                u16;
-                                                                        let mask =
-                                                                            2usize
-                                                                                as
-                                                                                u16;
-                                                                        let b2 =
-                                                                            (b2
-                                                                                 <<
-                                                                                 1usize)
-                                                                                &
-                                                                                mask;
-                                                                        bitfield_unit_val
-                                                                            |
-                                                                            b2
-                                                                    };
-                                                                let b3 =
-                                                                    b3 as u32
-                                                                        as
-                                                                        u16;
-                                                                let mask =
-                                                                    4usize as
-                                                                        u16;
-                                                                let b3 =
-                                                                    (b3 <<
-                                                                         2usize)
-                                                                        &
-                                                                        mask;
-                                                                bitfield_unit_val
-                                                                    | b3
-                                                            };
-                                                        let b4 =
-                                                            b4 as u32 as u16;
-                                                        let mask =
-                                                            8usize as u16;
-                                                        let b4 =
-                                                            (b4 << 3usize) &
-                                                                mask;
-                                                        bitfield_unit_val | b4
-                                                    };
-                                                let b5 = b5 as u32 as u16;
-                                                let mask = 16usize as u16;
-                                                let b5 =
-                                                    (b5 << 4usize) & mask;
-                                                bitfield_unit_val | b5
-                                            };
-                                        let b6 = b6 as u32 as u16;
-                                        let mask = 32usize as u16;
-                                        let b6 = (b6 << 5usize) & mask;
-                                        bitfield_unit_val | b6
-                                    };
-                                let b7 = b7 as u32 as u16;
-                                let mask = 64usize as u16;
-                                let b7 = (b7 << 6usize) & mask;
-                                bitfield_unit_val | b7
-                            };
-                        let b8 = b8 as u32 as u16;
-                        let mask = 128usize as u16;
-                        let b8 = (b8 << 7usize) & mask;
-                        bitfield_unit_val | b8
-                    };
-                let b9 = b9 as u32 as u16;
-                let mask = 256usize as u16;
-                let b9 = (b9 << 8usize) & mask;
-                bitfield_unit_val | b9
-            };
-        let b10 = b10 as u32 as u16;
-        let mask = 512usize as u16;
-        let b10 = (b10 << 9usize) & mask;
-        bitfield_unit_val | b10
+        ({
+             ({
+                  ({
+                       ({
+                            ({
+                                 ({
+                                      ({
+                                           ({
+                                                ({
+                                                     ({ 0 } |
+                                                          ((b1 as u32 as u16)
+                                                               << 0usize) &
+                                                              (1usize as u16))
+                                                 } |
+                                                     ((b2 as u32 as u16) <<
+                                                          1usize) &
+                                                         (2usize as u16))
+                                            } |
+                                                ((b3 as u32 as u16) << 2usize)
+                                                    & (4usize as u16))
+                                       } |
+                                           ((b4 as u32 as u16) << 3usize) &
+                                               (8usize as u16))
+                                  } |
+                                      ((b5 as u32 as u16) << 4usize) &
+                                          (16usize as u16))
+                             } |
+                                 ((b6 as u32 as u16) << 5usize) &
+                                     (32usize as u16))
+                        } | ((b7 as u32 as u16) << 6usize) & (64usize as u16))
+                   } | ((b8 as u32 as u16) << 7usize) & (128usize as u16))
+              } | ((b9 as u32 as u16) << 8usize) & (256usize as u16))
+         } | ((b10 as u32 as u16) << 9usize) & (512usize as u16))
     }
 }
 #[repr(C)]
@@ -396,18 +313,10 @@ impl B {
     #[inline]
     pub fn new_bitfield_1(foo: ::std::os::raw::c_uint,
                           bar: ::std::os::raw::c_uchar) -> u32 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let foo = foo as u32 as u32;
-                let mask = 2147483647usize as u32;
-                let foo = (foo << 0usize) & mask;
-                bitfield_unit_val | foo
-            };
-        let bar = bar as u8 as u32;
-        let mask = 2147483648usize as u32;
-        let bar = (bar << 31usize) & mask;
-        bitfield_unit_val | bar
+        ({
+             ({ 0 } |
+                  ((foo as u32 as u32) << 0usize) & (2147483647usize as u32))
+         } | ((bar as u8 as u32) << 31usize) & (2147483648usize as u32))
     }
 }
 #[repr(C)]
@@ -476,18 +385,8 @@ impl C {
     #[inline]
     pub fn new_bitfield_1(b1: ::std::os::raw::c_uint,
                           b2: ::std::os::raw::c_uint) -> u8 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let b1 = b1 as u32 as u8;
-                let mask = 1usize as u8;
-                let b1 = (b1 << 0usize) & mask;
-                bitfield_unit_val | b1
-            };
-        let b2 = b2 as u32 as u8;
-        let mask = 2usize as u8;
-        let b2 = (b2 << 1usize) & mask;
-        bitfield_unit_val | b2
+        ({ ({ 0 } | ((b1 as u32 as u8) << 0usize) & (1usize as u8)) } |
+             ((b2 as u32 as u8) << 1usize) & (2usize as u8))
     }
 }
 #[repr(C)]
@@ -567,25 +466,12 @@ impl Date1 {
     pub fn new_bitfield_1(nWeekDay: ::std::os::raw::c_ushort,
                           nMonthDay: ::std::os::raw::c_ushort,
                           nMonth: ::std::os::raw::c_ushort) -> u16 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val = { 0 };
-                        let nWeekDay = nWeekDay as u16 as u16;
-                        let mask = 7usize as u16;
-                        let nWeekDay = (nWeekDay << 0usize) & mask;
-                        bitfield_unit_val | nWeekDay
-                    };
-                let nMonthDay = nMonthDay as u16 as u16;
-                let mask = 504usize as u16;
-                let nMonthDay = (nMonthDay << 3usize) & mask;
-                bitfield_unit_val | nMonthDay
-            };
-        let nMonth = nMonth as u16 as u16;
-        let mask = 15872usize as u16;
-        let nMonth = (nMonth << 9usize) & mask;
-        bitfield_unit_val | nMonth
+        ({
+             ({
+                  ({ 0 } |
+                       ((nWeekDay as u16 as u16) << 0usize) & (7usize as u16))
+              } | ((nMonthDay as u16 as u16) << 3usize) & (504usize as u16))
+         } | ((nMonth as u16 as u16) << 9usize) & (15872usize as u16))
     }
     #[inline]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
@@ -607,11 +493,7 @@ impl Date1 {
     }
     #[inline]
     pub fn new_bitfield_2(nYear: ::std::os::raw::c_ushort) -> u8 {
-        let bitfield_unit_val = { 0 };
-        let nYear = nYear as u16 as u8;
-        let mask = 255usize as u8;
-        let nYear = (nYear << 0usize) & mask;
-        bitfield_unit_val | nYear
+        ({ 0 } | ((nYear as u16 as u8) << 0usize) & (255usize as u8))
     }
 }
 #[repr(C)]
@@ -696,25 +578,12 @@ impl Date2 {
     pub fn new_bitfield_1(nWeekDay: ::std::os::raw::c_ushort,
                           nMonthDay: ::std::os::raw::c_ushort,
                           nMonth: ::std::os::raw::c_ushort) -> u16 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val = { 0 };
-                        let nWeekDay = nWeekDay as u16 as u16;
-                        let mask = 7usize as u16;
-                        let nWeekDay = (nWeekDay << 0usize) & mask;
-                        bitfield_unit_val | nWeekDay
-                    };
-                let nMonthDay = nMonthDay as u16 as u16;
-                let mask = 504usize as u16;
-                let nMonthDay = (nMonthDay << 3usize) & mask;
-                bitfield_unit_val | nMonthDay
-            };
-        let nMonth = nMonth as u16 as u16;
-        let mask = 15872usize as u16;
-        let nMonth = (nMonth << 9usize) & mask;
-        bitfield_unit_val | nMonth
+        ({
+             ({
+                  ({ 0 } |
+                       ((nWeekDay as u16 as u16) << 0usize) & (7usize as u16))
+              } | ((nMonthDay as u16 as u16) << 3usize) & (504usize as u16))
+         } | ((nMonth as u16 as u16) << 9usize) & (15872usize as u16))
     }
     #[inline]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
@@ -736,10 +605,6 @@ impl Date2 {
     }
     #[inline]
     pub fn new_bitfield_2(nYear: ::std::os::raw::c_ushort) -> u8 {
-        let bitfield_unit_val = { 0 };
-        let nYear = nYear as u16 as u8;
-        let mask = 255usize as u8;
-        let nYear = (nYear << 0usize) & mask;
-        bitfield_unit_val | nYear
+        ({ 0 } | ((nYear as u16 as u8) << 0usize) & (255usize as u8))
     }
 }

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -63,17 +63,9 @@ impl mach_msg_type_descriptor_t {
     #[inline]
     pub fn new_bitfield_1(pad3: ::std::os::raw::c_uint,
                           type_: ::std::os::raw::c_uint) -> u32 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let pad3 = pad3 as u32 as u32;
-                let mask = 16777215usize as u32;
-                let pad3 = (pad3 << 0usize) & mask;
-                bitfield_unit_val | pad3
-            };
-        let type_ = type_ as u32 as u32;
-        let mask = 4278190080usize as u32;
-        let type_ = (type_ << 24usize) & mask;
-        bitfield_unit_val | type_
+        ({
+             ({ 0 } |
+                  ((pad3 as u32 as u32) << 0usize) & (16777215usize as u32))
+         } | ((type_ as u32 as u32) << 24usize) & (4278190080usize as u32))
     }
 }

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -168,18 +168,13 @@ impl jsval_layout__bindgen_ty_1 {
     }
     #[inline]
     pub fn new_bitfield_1(payload47: u64, tag: JSValueTag) -> u64 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let payload47 = payload47 as u64 as u64;
-                let mask = 140737488355327usize as u64;
-                let payload47 = (payload47 << 0usize) & mask;
-                bitfield_unit_val | payload47
-            };
-        let tag = tag as u32 as u64;
-        let mask = 18446603336221196288usize as u64;
-        let tag = (tag << 47usize) & mask;
-        bitfield_unit_val | tag
+        ({
+             ({ 0 } |
+                  ((payload47 as u64 as u64) << 0usize) &
+                      (140737488355327usize as u64))
+         } |
+             ((tag as u32 as u64) << 47usize) &
+                 (18446603336221196288usize as u64))
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -147,24 +147,12 @@ impl rte_eth_link {
     #[inline]
     pub fn new_bitfield_1(link_duplex: u16, link_autoneg: u16,
                           link_status: u16) -> u8 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val = { 0 };
-                        let link_duplex = link_duplex as u16 as u8;
-                        let mask = 1usize as u8;
-                        let link_duplex = (link_duplex << 0usize) & mask;
-                        bitfield_unit_val | link_duplex
-                    };
-                let link_autoneg = link_autoneg as u16 as u8;
-                let mask = 2usize as u8;
-                let link_autoneg = (link_autoneg << 1usize) & mask;
-                bitfield_unit_val | link_autoneg
-            };
-        let link_status = link_status as u16 as u8;
-        let mask = 4usize as u8;
-        let link_status = (link_status << 2usize) & mask;
-        bitfield_unit_val | link_status
+        ({
+             ({
+                  ({ 0 } |
+                       ((link_duplex as u16 as u8) << 0usize) &
+                           (1usize as u8))
+              } | ((link_autoneg as u16 as u8) << 1usize) & (2usize as u8))
+         } | ((link_status as u16 as u8) << 2usize) & (4usize as u8))
     }
 }

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -287,113 +287,41 @@ impl rte_eth_rxmode {
                           hw_vlan_extend: u16, jumbo_frame: u16,
                           hw_strip_crc: u16, enable_scatter: u16,
                           enable_lro: u16) -> u16 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val =
-                            {
-                                let bitfield_unit_val =
-                                    {
-                                        let bitfield_unit_val =
-                                            {
-                                                let bitfield_unit_val =
-                                                    {
-                                                        let bitfield_unit_val =
-                                                            {
-                                                                let bitfield_unit_val =
-                                                                    {
-                                                                        let bitfield_unit_val =
-                                                                            {
-                                                                                0
-                                                                            };
-                                                                        let header_split =
-                                                                            header_split
-                                                                                as
-                                                                                u16
-                                                                                as
-                                                                                u16;
-                                                                        let mask =
-                                                                            1usize
-                                                                                as
-                                                                                u16;
-                                                                        let header_split =
-                                                                            (header_split
-                                                                                 <<
-                                                                                 0usize)
-                                                                                &
-                                                                                mask;
-                                                                        bitfield_unit_val
-                                                                            |
-                                                                            header_split
-                                                                    };
-                                                                let hw_ip_checksum =
-                                                                    hw_ip_checksum
-                                                                        as u16
-                                                                        as
-                                                                        u16;
-                                                                let mask =
-                                                                    2usize as
-                                                                        u16;
-                                                                let hw_ip_checksum =
-                                                                    (hw_ip_checksum
-                                                                         <<
-                                                                         1usize)
-                                                                        &
-                                                                        mask;
-                                                                bitfield_unit_val
-                                                                    |
-                                                                    hw_ip_checksum
-                                                            };
-                                                        let hw_vlan_filter =
-                                                            hw_vlan_filter as
-                                                                u16 as u16;
-                                                        let mask =
-                                                            4usize as u16;
-                                                        let hw_vlan_filter =
-                                                            (hw_vlan_filter <<
-                                                                 2usize) &
-                                                                mask;
-                                                        bitfield_unit_val |
-                                                            hw_vlan_filter
-                                                    };
-                                                let hw_vlan_strip =
-                                                    hw_vlan_strip as u16 as
-                                                        u16;
-                                                let mask = 8usize as u16;
-                                                let hw_vlan_strip =
-                                                    (hw_vlan_strip << 3usize)
-                                                        & mask;
-                                                bitfield_unit_val |
-                                                    hw_vlan_strip
-                                            };
-                                        let hw_vlan_extend =
-                                            hw_vlan_extend as u16 as u16;
-                                        let mask = 16usize as u16;
-                                        let hw_vlan_extend =
-                                            (hw_vlan_extend << 4usize) & mask;
-                                        bitfield_unit_val | hw_vlan_extend
-                                    };
-                                let jumbo_frame = jumbo_frame as u16 as u16;
-                                let mask = 32usize as u16;
-                                let jumbo_frame =
-                                    (jumbo_frame << 5usize) & mask;
-                                bitfield_unit_val | jumbo_frame
-                            };
-                        let hw_strip_crc = hw_strip_crc as u16 as u16;
-                        let mask = 64usize as u16;
-                        let hw_strip_crc = (hw_strip_crc << 6usize) & mask;
-                        bitfield_unit_val | hw_strip_crc
-                    };
-                let enable_scatter = enable_scatter as u16 as u16;
-                let mask = 128usize as u16;
-                let enable_scatter = (enable_scatter << 7usize) & mask;
-                bitfield_unit_val | enable_scatter
-            };
-        let enable_lro = enable_lro as u16 as u16;
-        let mask = 256usize as u16;
-        let enable_lro = (enable_lro << 8usize) & mask;
-        bitfield_unit_val | enable_lro
+        ({
+             ({
+                  ({
+                       ({
+                            ({
+                                 ({
+                                      ({
+                                           ({
+                                                ({ 0 } |
+                                                     ((header_split as u16 as
+                                                           u16) << 0usize) &
+                                                         (1usize as u16))
+                                            } |
+                                                ((hw_ip_checksum as u16 as
+                                                      u16) << 1usize) &
+                                                    (2usize as u16))
+                                       } |
+                                           ((hw_vlan_filter as u16 as u16) <<
+                                                2usize) & (4usize as u16))
+                                  } |
+                                      ((hw_vlan_strip as u16 as u16) <<
+                                           3usize) & (8usize as u16))
+                             } |
+                                 ((hw_vlan_extend as u16 as u16) << 4usize) &
+                                     (16usize as u16))
+                        } |
+                            ((jumbo_frame as u16 as u16) << 5usize) &
+                                (32usize as u16))
+                   } |
+                       ((hw_strip_crc as u16 as u16) << 6usize) &
+                           (64usize as u16))
+              } |
+                  ((enable_scatter as u16 as u16) << 7usize) &
+                      (128usize as u16))
+         } | ((enable_lro as u16 as u16) << 8usize) & (256usize as u16))
     }
 }
 #[repr(u32)]
@@ -502,29 +430,15 @@ impl rte_eth_txmode {
     pub fn new_bitfield_1(hw_vlan_reject_tagged: u8,
                           hw_vlan_reject_untagged: u8,
                           hw_vlan_insert_pvid: u8) -> u8 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val = { 0 };
-                        let hw_vlan_reject_tagged =
-                            hw_vlan_reject_tagged as u8 as u8;
-                        let mask = 1usize as u8;
-                        let hw_vlan_reject_tagged =
-                            (hw_vlan_reject_tagged << 0usize) & mask;
-                        bitfield_unit_val | hw_vlan_reject_tagged
-                    };
-                let hw_vlan_reject_untagged =
-                    hw_vlan_reject_untagged as u8 as u8;
-                let mask = 2usize as u8;
-                let hw_vlan_reject_untagged =
-                    (hw_vlan_reject_untagged << 1usize) & mask;
-                bitfield_unit_val | hw_vlan_reject_untagged
-            };
-        let hw_vlan_insert_pvid = hw_vlan_insert_pvid as u8 as u8;
-        let mask = 4usize as u8;
-        let hw_vlan_insert_pvid = (hw_vlan_insert_pvid << 2usize) & mask;
-        bitfield_unit_val | hw_vlan_insert_pvid
+        ({
+             ({
+                  ({ 0 } |
+                       ((hw_vlan_reject_tagged as u8 as u8) << 0usize) &
+                           (1usize as u8))
+              } |
+                  ((hw_vlan_reject_untagged as u8 as u8) << 1usize) &
+                      (2usize as u8))
+         } | ((hw_vlan_insert_pvid as u8 as u8) << 2usize) & (4usize as u8))
     }
 }
 /**

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -306,65 +306,33 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     pub fn new_bitfield_1(l2_type: u32, l3_type: u32, l4_type: u32,
                           tun_type: u32, inner_l2_type: u32,
                           inner_l3_type: u32, inner_l4_type: u32) -> u32 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val =
-                            {
-                                let bitfield_unit_val =
-                                    {
-                                        let bitfield_unit_val =
-                                            {
-                                                let bitfield_unit_val =
-                                                    {
-                                                        let bitfield_unit_val =
-                                                            { 0 };
-                                                        let l2_type =
-                                                            l2_type as u32 as
-                                                                u32;
-                                                        let mask =
-                                                            15usize as u32;
-                                                        let l2_type =
-                                                            (l2_type <<
-                                                                 0usize) &
-                                                                mask;
-                                                        bitfield_unit_val |
-                                                            l2_type
-                                                    };
-                                                let l3_type =
-                                                    l3_type as u32 as u32;
-                                                let mask = 240usize as u32;
-                                                let l3_type =
-                                                    (l3_type << 4usize) &
-                                                        mask;
-                                                bitfield_unit_val | l3_type
-                                            };
-                                        let l4_type = l4_type as u32 as u32;
-                                        let mask = 3840usize as u32;
-                                        let l4_type =
-                                            (l4_type << 8usize) & mask;
-                                        bitfield_unit_val | l4_type
-                                    };
-                                let tun_type = tun_type as u32 as u32;
-                                let mask = 61440usize as u32;
-                                let tun_type = (tun_type << 12usize) & mask;
-                                bitfield_unit_val | tun_type
-                            };
-                        let inner_l2_type = inner_l2_type as u32 as u32;
-                        let mask = 983040usize as u32;
-                        let inner_l2_type = (inner_l2_type << 16usize) & mask;
-                        bitfield_unit_val | inner_l2_type
-                    };
-                let inner_l3_type = inner_l3_type as u32 as u32;
-                let mask = 15728640usize as u32;
-                let inner_l3_type = (inner_l3_type << 20usize) & mask;
-                bitfield_unit_val | inner_l3_type
-            };
-        let inner_l4_type = inner_l4_type as u32 as u32;
-        let mask = 251658240usize as u32;
-        let inner_l4_type = (inner_l4_type << 24usize) & mask;
-        bitfield_unit_val | inner_l4_type
+        ({
+             ({
+                  ({
+                       ({
+                            ({
+                                 ({
+                                      ({ 0 } |
+                                           ((l2_type as u32 as u32) << 0usize)
+                                               & (15usize as u32))
+                                  } |
+                                      ((l3_type as u32 as u32) << 4usize) &
+                                          (240usize as u32))
+                             } |
+                                 ((l4_type as u32 as u32) << 8usize) &
+                                     (3840usize as u32))
+                        } |
+                            ((tun_type as u32 as u32) << 12usize) &
+                                (61440usize as u32))
+                   } |
+                       ((inner_l2_type as u32 as u32) << 16usize) &
+                           (983040usize as u32))
+              } |
+                  ((inner_l3_type as u32 as u32) << 20usize) &
+                      (15728640usize as u32))
+         } |
+             ((inner_l4_type as u32 as u32) << 24usize) &
+                 (251658240usize as u32))
     }
 }
 #[test]
@@ -730,49 +698,29 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     pub fn new_bitfield_1(l2_len: u64, l3_len: u64, l4_len: u64,
                           tso_segsz: u64, outer_l3_len: u64,
                           outer_l2_len: u64) -> u64 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val =
-                            {
-                                let bitfield_unit_val =
-                                    {
-                                        let bitfield_unit_val =
-                                            {
-                                                let bitfield_unit_val = { 0 };
-                                                let l2_len =
-                                                    l2_len as u64 as u64;
-                                                let mask = 127usize as u64;
-                                                let l2_len =
-                                                    (l2_len << 0usize) & mask;
-                                                bitfield_unit_val | l2_len
-                                            };
-                                        let l3_len = l3_len as u64 as u64;
-                                        let mask = 65408usize as u64;
-                                        let l3_len =
-                                            (l3_len << 7usize) & mask;
-                                        bitfield_unit_val | l3_len
-                                    };
-                                let l4_len = l4_len as u64 as u64;
-                                let mask = 16711680usize as u64;
-                                let l4_len = (l4_len << 16usize) & mask;
-                                bitfield_unit_val | l4_len
-                            };
-                        let tso_segsz = tso_segsz as u64 as u64;
-                        let mask = 1099494850560usize as u64;
-                        let tso_segsz = (tso_segsz << 24usize) & mask;
-                        bitfield_unit_val | tso_segsz
-                    };
-                let outer_l3_len = outer_l3_len as u64 as u64;
-                let mask = 561850441793536usize as u64;
-                let outer_l3_len = (outer_l3_len << 40usize) & mask;
-                bitfield_unit_val | outer_l3_len
-            };
-        let outer_l2_len = outer_l2_len as u64 as u64;
-        let mask = 71494644084506624usize as u64;
-        let outer_l2_len = (outer_l2_len << 49usize) & mask;
-        bitfield_unit_val | outer_l2_len
+        ({
+             ({
+                  ({
+                       ({
+                            ({
+                                 ({ 0 } |
+                                      ((l2_len as u64 as u64) << 0usize) &
+                                          (127usize as u64))
+                             } |
+                                 ((l3_len as u64 as u64) << 7usize) &
+                                     (65408usize as u64))
+                        } |
+                            ((l4_len as u64 as u64) << 16usize) &
+                                (16711680usize as u64))
+                   } |
+                       ((tso_segsz as u64 as u64) << 24usize) &
+                           (1099494850560usize as u64))
+              } |
+                  ((outer_l3_len as u64 as u64) << 40usize) &
+                      (561850441793536usize as u64))
+         } |
+             ((outer_l2_len as u64 as u64) << 49usize) &
+                 (71494644084506624usize as u64))
     }
 }
 #[test]

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -59,17 +59,7 @@ impl C {
     }
     #[inline]
     pub fn new_bitfield_1(a: bool, b: bool) -> u8 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let a = a as u8 as u8;
-                let mask = 1usize as u8;
-                let a = (a << 0usize) & mask;
-                bitfield_unit_val | a
-            };
-        let b = b as u8 as u8;
-        let mask = 254usize as u8;
-        let b = (b << 1usize) & mask;
-        bitfield_unit_val | b
+        ({ ({ 0 } | ((a as u8 as u8) << 0usize) & (1usize as u8)) } |
+             ((b as u8 as u8) << 1usize) & (254usize as u8))
     }
 }

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -105,32 +105,12 @@ impl bitfield {
                           b: ::std::os::raw::c_ushort,
                           c: ::std::os::raw::c_ushort,
                           d: ::std::os::raw::c_ushort) -> u8 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val =
-                            {
-                                let bitfield_unit_val = { 0 };
-                                let a = a as u16 as u8;
-                                let mask = 1usize as u8;
-                                let a = (a << 0usize) & mask;
-                                bitfield_unit_val | a
-                            };
-                        let b = b as u16 as u8;
-                        let mask = 2usize as u8;
-                        let b = (b << 1usize) & mask;
-                        bitfield_unit_val | b
-                    };
-                let c = c as u16 as u8;
-                let mask = 4usize as u8;
-                let c = (c << 2usize) & mask;
-                bitfield_unit_val | c
-            };
-        let d = d as u16 as u8;
-        let mask = 192usize as u8;
-        let d = (d << 6usize) & mask;
-        bitfield_unit_val | d
+        ({
+             ({
+                  ({ ({ 0 } | ((a as u16 as u8) << 0usize) & (1usize as u8)) }
+                       | ((b as u16 as u8) << 1usize) & (2usize as u8))
+              } | ((c as u16 as u8) << 2usize) & (4usize as u8))
+         } | ((d as u16 as u8) << 6usize) & (192usize as u8))
     }
     #[inline]
     pub fn f(&self) -> ::std::os::raw::c_uint {
@@ -152,11 +132,7 @@ impl bitfield {
     }
     #[inline]
     pub fn new_bitfield_2(f: ::std::os::raw::c_uint) -> u8 {
-        let bitfield_unit_val = { 0 };
-        let f = f as u32 as u8;
-        let mask = 3usize as u8;
-        let f = (f << 0usize) & mask;
-        bitfield_unit_val | f
+        ({ 0 } | ((f as u32 as u8) << 0usize) & (3usize as u8))
     }
     #[inline]
     pub fn g(&self) -> ::std::os::raw::c_uint {
@@ -178,10 +154,6 @@ impl bitfield {
     }
     #[inline]
     pub fn new_bitfield_3(g: ::std::os::raw::c_uint) -> u32 {
-        let bitfield_unit_val = { 0 };
-        let g = g as u32 as u32;
-        let mask = 4294967295usize as u32;
-        let g = (g << 0usize) & mask;
-        bitfield_unit_val | g
+        ({ 0 } | ((g as u32 as u32) << 0usize) & (4294967295usize as u32))
     }
 }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -91,18 +91,8 @@ impl foo__bindgen_ty_1 {
     #[inline]
     pub fn new_bitfield_1(b: ::std::os::raw::c_int, c: ::std::os::raw::c_int)
      -> u32 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let b = b as u32 as u32;
-                let mask = 127usize as u32;
-                let b = (b << 0usize) & mask;
-                bitfield_unit_val | b
-            };
-        let c = c as u32 as u32;
-        let mask = 4294967168usize as u32;
-        let c = (c << 7usize) & mask;
-        bitfield_unit_val | c
+        ({ ({ 0 } | ((b as u32 as u32) << 0usize) & (127usize as u32)) } |
+             ((c as u32 as u32) << 7usize) & (4294967168usize as u32))
     }
 }
 #[test]

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -144,18 +144,10 @@ impl Weird {
     #[inline]
     pub fn new_bitfield_1(bitTest: ::std::os::raw::c_uint,
                           bitTest2: ::std::os::raw::c_uint) -> u32 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val = { 0 };
-                let bitTest = bitTest as u32 as u32;
-                let mask = 65535usize as u32;
-                let bitTest = (bitTest << 0usize) & mask;
-                bitfield_unit_val | bitTest
-            };
-        let bitTest2 = bitTest2 as u32 as u32;
-        let mask = 2147418112usize as u32;
-        let bitTest2 = (bitTest2 << 16usize) & mask;
-        bitfield_unit_val | bitTest2
+        ({
+             ({ 0 } |
+                  ((bitTest as u32 as u32) << 0usize) & (65535usize as u32))
+         } | ((bitTest2 as u32 as u32) << 16usize) & (2147418112usize as u32))
     }
     #[inline]
     pub fn mFillOpacitySource(&self) -> nsStyleSVGOpacitySource {
@@ -234,40 +226,21 @@ impl Weird {
                           mStrokeOpacitySource: nsStyleSVGOpacitySource,
                           mStrokeDasharrayFromObject: bool,
                           mStrokeDashoffsetFromObject: bool) -> u8 {
-        let bitfield_unit_val =
-            {
-                let bitfield_unit_val =
-                    {
-                        let bitfield_unit_val =
-                            {
-                                let bitfield_unit_val = { 0 };
-                                let mFillOpacitySource =
-                                    mFillOpacitySource as u32 as u8;
-                                let mask = 7usize as u8;
-                                let mFillOpacitySource =
-                                    (mFillOpacitySource << 0usize) & mask;
-                                bitfield_unit_val | mFillOpacitySource
-                            };
-                        let mStrokeOpacitySource =
-                            mStrokeOpacitySource as u32 as u8;
-                        let mask = 56usize as u8;
-                        let mStrokeOpacitySource =
-                            (mStrokeOpacitySource << 3usize) & mask;
-                        bitfield_unit_val | mStrokeOpacitySource
-                    };
-                let mStrokeDasharrayFromObject =
-                    mStrokeDasharrayFromObject as u8 as u8;
-                let mask = 64usize as u8;
-                let mStrokeDasharrayFromObject =
-                    (mStrokeDasharrayFromObject << 6usize) & mask;
-                bitfield_unit_val | mStrokeDasharrayFromObject
-            };
-        let mStrokeDashoffsetFromObject =
-            mStrokeDashoffsetFromObject as u8 as u8;
-        let mask = 128usize as u8;
-        let mStrokeDashoffsetFromObject =
-            (mStrokeDashoffsetFromObject << 7usize) & mask;
-        bitfield_unit_val | mStrokeDashoffsetFromObject
+        ({
+             ({
+                  ({
+                       ({ 0 } |
+                            ((mFillOpacitySource as u32 as u8) << 0usize) &
+                                (7usize as u8))
+                   } |
+                       ((mStrokeOpacitySource as u32 as u8) << 3usize) &
+                           (56usize as u8))
+              } |
+                  ((mStrokeDasharrayFromObject as u8 as u8) << 6usize) &
+                      (64usize as u8))
+         } |
+             ((mStrokeDashoffsetFromObject as u8 as u8) << 7usize) &
+                 (128usize as u8))
     }
     #[inline]
     pub fn mStrokeWidthFromObject(&self) -> bool {
@@ -289,11 +262,8 @@ impl Weird {
     }
     #[inline]
     pub fn new_bitfield_3(mStrokeWidthFromObject: bool) -> u8 {
-        let bitfield_unit_val = { 0 };
-        let mStrokeWidthFromObject = mStrokeWidthFromObject as u8 as u8;
-        let mask = 1usize as u8;
-        let mStrokeWidthFromObject =
-            (mStrokeWidthFromObject << 0usize) & mask;
-        bitfield_unit_val | mStrokeWidthFromObject
+        ({ 0 } |
+             ((mStrokeWidthFromObject as u8 as u8) << 0usize) &
+                 (1usize as u8))
     }
 }


### PR DESCRIPTION
Const function can't have variables or blocks.

r? @fitzgen 