### PR TITLE
Only run call-conv-field.h test on linux

### DIFF
--- a/tests/headers/call-conv-field.h
+++ b/tests/headers/call-conv-field.h
@@ -1,5 +1,11 @@
 // bindgen-flags: -- -target i686-pc-win32
 // bindgen-unstable
+// bindgen-generate-bindings-on-linux-only
+//
+// The linux-only thing is a hack around our lack of understanding when
+// bindgen's target_os != the bindings' target_os :(
+//
+// https://github.com/servo/rust-bindgen/issues/593
 
 struct JNINativeInterface_ {
   int (__stdcall *GetVersion)(void *env);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -92,6 +92,9 @@ fn create_bindgen_builder(header: &PathBuf) -> Result<Option<Builder>, Error> {
                 .map(ToString::to_string)
                 .chain(flags)
                 .collect();
+        } else if line.contains("bindgen-generate-bindings-on-linux-only") &&
+          !cfg!(target_os = "linux") {
+              return Ok(None);
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -75,8 +75,12 @@ fn create_bindgen_builder(header: &PathBuf) -> Result<Option<Builder>, Error> {
     // Scoop up bindgen-flags from test header
     let mut flags = Vec::with_capacity(2);
 
-    for line in reader.lines().take(3) {
+    for line in reader.lines() {
         let line = try!(line);
+        if !line.starts_with("// bindgen") {
+            continue;
+        }
+
         if line.contains("bindgen-flags: ") {
             let extra_flags = line.split("bindgen-flags: ")
                 .last()


### PR DESCRIPTION
This is a temporary work around for issue #593 and this test failing on MacOS because we don't currently handle when the bindgen executable's target OS is not the same as the emitted bindings' target OS.

r? @emilio 