### PR TITLE
Rename `AsNamed` to `AsTemplateParam`

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -23,7 +23,7 @@ use ir::item_kind::ItemKind;
 use ir::layout::Layout;
 use ir::module::Module;
 use ir::objc::{ObjCInterface, ObjCMethod};
-use ir::template::{AsNamed, TemplateInstantiation, TemplateParameters};
+use ir::template::{AsTemplateParam, TemplateInstantiation, TemplateParameters};
 use ir::ty::{Type, TypeKind};
 use ir::var::Var;
 
@@ -641,7 +641,7 @@ impl CodeGenerator for Type {
                     if let Some(ref params) = used_template_params {
                         for template_param in params {
                             if let Some(id) =
-                                template_param.as_named(ctx, &()) {
+                                template_param.as_template_param(ctx, &()) {
                                 let template_param = ctx.resolve_type(id);
                                 if template_param.is_invalid_named_type() {
                                     warn!("Item contained invalid template \
@@ -2729,7 +2729,7 @@ impl TryToRustTy for Type {
                 let template_params = item.used_template_params(ctx)
                     .unwrap_or(vec![])
                     .into_iter()
-                    .filter(|param| param.is_named(ctx, &()))
+                    .filter(|param| param.is_template_param(ctx, &()))
                     .collect::<Vec<_>>();
 
                 let spelling = self.name().expect("Unnamed alias?");

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -8,7 +8,7 @@ use super::function::Function;
 use super::item_kind::ItemKind;
 use super::layout::Opaque;
 use super::module::Module;
-use super::template::{AsNamed, TemplateParameters};
+use super::template::{AsTemplateParam, TemplateParameters};
 use super::traversal::{EdgeKind, Trace, Tracer};
 use super::ty::{Type, TypeKind};
 use clang;
@@ -131,28 +131,28 @@ impl<'a, 'b> Iterator for ItemAncestorsIter<'a, 'b>
     }
 }
 
-impl AsNamed for ItemId {
+impl AsTemplateParam for ItemId {
     type Extra = ();
 
-    fn as_named(&self, ctx: &BindgenContext, _: &()) -> Option<ItemId> {
-        ctx.resolve_item(*self).as_named(ctx, &())
+    fn as_template_param(&self, ctx: &BindgenContext, _: &()) -> Option<ItemId> {
+        ctx.resolve_item(*self).as_template_param(ctx, &())
     }
 }
 
-impl AsNamed for Item {
+impl AsTemplateParam for Item {
     type Extra = ();
 
-    fn as_named(&self, ctx: &BindgenContext, _: &()) -> Option<ItemId> {
-        self.kind.as_named(ctx, self)
+    fn as_template_param(&self, ctx: &BindgenContext, _: &()) -> Option<ItemId> {
+        self.kind.as_template_param(ctx, self)
     }
 }
 
-impl AsNamed for ItemKind {
+impl AsTemplateParam for ItemKind {
     type Extra = Item;
 
-    fn as_named(&self, ctx: &BindgenContext, item: &Item) -> Option<ItemId> {
+    fn as_template_param(&self, ctx: &BindgenContext, item: &Item) -> Option<ItemId> {
         match *self {
-            ItemKind::Type(ref ty) => ty.as_named(ctx, item),
+            ItemKind::Type(ref ty) => ty.as_template_param(ctx, item),
             ItemKind::Module(..) |
             ItemKind::Function(..) |
             ItemKind::Var(..) => None,
@@ -756,7 +756,7 @@ impl Item {
 
         // Named template type arguments are never namespaced, and never
         // mangled.
-        if target.is_named(ctx, &()) {
+        if target.is_template_param(ctx, &()) {
             return base_name;
         }
 

--- a/src/ir/template.rs
+++ b/src/ir/template.rs
@@ -176,19 +176,19 @@ pub trait TemplateParameters {
 }
 
 /// A trait for things which may or may not be a named template type parameter.
-pub trait AsNamed {
+pub trait AsTemplateParam {
     /// Any extra information the implementor might need to make this decision.
     type Extra;
 
     /// Convert this thing to the item id of a named template type parameter.
-    fn as_named(&self,
-                ctx: &BindgenContext,
-                extra: &Self::Extra)
-                -> Option<ItemId>;
+    fn as_template_param(&self,
+                         ctx: &BindgenContext,
+                         extra: &Self::Extra)
+                         -> Option<ItemId>;
 
     /// Is this a named template type parameter?
-    fn is_named(&self, ctx: &BindgenContext, extra: &Self::Extra) -> bool {
-        self.as_named(ctx, extra).is_some()
+    fn is_template_param(&self, ctx: &BindgenContext, extra: &Self::Extra) -> bool {
+        self.as_template_param(ctx, extra).is_some()
     }
 }
 

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -10,7 +10,7 @@ use super::int::IntKind;
 use super::item::Item;
 use super::layout::{Layout, Opaque};
 use super::objc::ObjCInterface;
-use super::template::{AsNamed, TemplateInstantiation, TemplateParameters};
+use super::template::{AsTemplateParam, TemplateInstantiation, TemplateParameters};
 use super::traversal::{EdgeKind, Trace, Tracer};
 use clang::{self, Cursor};
 use parse::{ClangItemParser, ParseError, ParseResult};
@@ -374,21 +374,21 @@ impl Type {
     }
 }
 
-impl AsNamed for Type {
+impl AsTemplateParam for Type {
     type Extra = Item;
 
-    fn as_named(&self, ctx: &BindgenContext, item: &Item) -> Option<ItemId> {
-        self.kind.as_named(ctx, item)
+    fn as_template_param(&self, ctx: &BindgenContext, item: &Item) -> Option<ItemId> {
+        self.kind.as_template_param(ctx, item)
     }
 }
 
-impl AsNamed for TypeKind {
+impl AsTemplateParam for TypeKind {
     type Extra = Item;
 
-    fn as_named(&self, ctx: &BindgenContext, item: &Item) -> Option<ItemId> {
+    fn as_template_param(&self, ctx: &BindgenContext, item: &Item) -> Option<ItemId> {
         match *self {
             TypeKind::Named => Some(item.id()),
-            TypeKind::ResolvedTypeRef(id) => id.as_named(ctx, &()),
+            TypeKind::ResolvedTypeRef(id) => id.as_template_param(ctx, &()),
             _ => None,
         }
     }


### PR DESCRIPTION
And also its trait methods `is_named` and `as_named` into `is_template_param`
and `as_template_param` respectively.

These new names better reflect what the trait is about.

r? @emilio 