### PR TITLE
Drop llvm@3.9 versioning for homebrew.

### DIFF
--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -28,7 +28,7 @@ Download and install the official pre-built binary from
 If you use Homebrew:
 
 ```bash
-$ brew install llvm@3.9
+$ brew install llvm
 ```
 
 If you use MacPorts:


### PR DESCRIPTION
Homebrew now defaults to llvm 4.0.x so there's no need to specify a specific version to get compatibility, unless we specifically want people using 3.9.