### PR TITLE
Fix tests/test-one.sh.

### DIFF
--- a/tests/test-one.sh
+++ b/tests/test-one.sh
@@ -22,7 +22,7 @@ export RUST_BACKTRACE=1
 
 unique_fuzzy_file() {
     local pattern="$1"
-    local results="$(find ./tests/headers -type f | egrep -i "*$pattern*")"
+    local results="$(find ./tests/headers -type f | egrep -i "$pattern")"
     local num_results=$(echo "$results" | wc -l)
 
     if [[ -z "$results" ]]; then


### PR DESCRIPTION
On Mac OS where egrep is != GNU grep, the script fails with

~~~
egrep: repetition-operator operand invalid
ERROR: no files found with pattern "virtual_inheritance"
~~~~

The `$pattern` is supposed to be a substring in the test name to run.
The leading and trailing stars are wrong, since egrep takes a regular expression, not a glob.