### PR TITLE
Always log the libclang version when generating bindings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,8 @@ extern crate log;
 extern crate clang_sys;
 extern crate clap;
 
-use bindgen::clang_version;
 use std::env;
 use std::panic;
-
-#[macro_use]
-#[cfg(not(feature="logging"))]
-mod log_stubs;
 
 mod options;
 use options::builder_from_flags;
@@ -29,26 +24,6 @@ pub fn main() {
         .expect("Failed to set logger.");
 
     let bind_args: Vec<_> = env::args().collect();
-
-    let version = clang_version();
-    let expected_version = if cfg!(feature = "testing_only_libclang_4") {
-        (4, 0)
-    } else if cfg!(feature = "testing_only_libclang_3_8") {
-        (3, 8)
-    } else {
-        // Default to 3.9.
-        (3, 9)
-    };
-
-    info!("Clang Version: {}", version.full);
-
-    match version.parsed {
-        None => warn!("Couldn't parse libclang version"),
-        Some(version) if version != expected_version => {
-            warn!("Using clang {:?}, expected {:?}", version, expected_version);
-        }
-        _ => {}
-    }
 
     match builder_from_flags(bind_args.into_iter()) {
         Ok((builder, output, verbose)) => {


### PR DESCRIPTION
Before, we would only log the libclang version when running bindgen on the command line. Now we do it every time bindings are generated. This is super useful information to have when debugging bindgen invocations.

Woops, I pushed this yesterday, but never created a PR! Really need this to debug why bindgen is getting weird libclang bugs in mozjs's CI.

r? @emilio 