### PR TITLE
No system includes in test headers

### DIFF
--- a/ci/no-includes.sh
+++ b/ci/no-includes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Don't allow any system include directives in tests.
+
+set -eu
+cd "$(dirname "$0")/.."
+
+echo "Checking for #include directives of system headers..."
+
+grep -rn '#include\s*<.*>' tests/headers || {
+    echo "Found none; OK!"
+    exit 0
+}
+
+echo "
+Found a test with an #include directive of a system header file!
+
+There is no guarantee that the system running the tests has the header
+file, let alone the same version of it that you have. Any test with such an
+include directive won't reliably produce the consistent bindings across systems.
+"
+
+exit 1

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,6 +5,9 @@ cd "$(dirname "$0")/.."
 
 export RUST_BACKTRACE=1
 
+# Disallow system header file includes in our test suite.
+./ci/no-includes.sh
+
 # Regenerate the test headers' bindings in debug and release modes, and assert
 # that we always get the expected generated bindings.
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,7 @@ use bindgen::{Builder, builder};
 use std::fs;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Read, Write};
 use std::path::PathBuf;
+use std::process::Command;
 
 #[path="../src/options.rs"]
 mod options;
@@ -212,4 +213,15 @@ fn test_multiple_header_calls_in_builder() {
 
         panic!();
     }
+}
+
+#[test]
+fn no_system_header_includes() {
+    assert!(Command::new("./ci/no-includes.sh")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .spawn()
+            .expect("should spawn ./ci/no-includes.sh OK")
+            .wait()
+            .expect("should wait for ./ci/no-includes OK")
+            .success());
 }


### PR DESCRIPTION
See each commit message.

Disallowing *system* includes and not *all* includes because we have one local include in `extern.hpp`, and local includes will at least be consistent/reproducible.

r? @emilio 