### PR TITLE
Update the tutorial for the latest bindgen release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ script:
 after_success:
   - test "$TRAVIS_PULL_REQUEST" == "false" &&
     test "$TRAVIS_BRANCH" == "master" &&
-    test "$BINDGEN_FEATURES" == "" &&
-    test "$LLVM_VERSION" == "3.9.0" &&
     ./ci/deploy-book.sh
 
 notifications:

--- a/book/src/tutorial-0.md
+++ b/book/src/tutorial-0.md
@@ -9,4 +9,4 @@ systems) on-the-fly.
 [**TL;DR?** The full tutorial code is available here.][example]
 
 [tutorial]: http://fitzgeraldnick.com/2016/12/14/using-libbindgen-in-build-rs.html
-[example]: https://github.com/fitzgen/libbindgen-tutorial-bzip2-sys
+[example]: https://github.com/fitzgen/bindgen-tutorial-bzip2-sys

--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -5,5 +5,5 @@ Declare a build-time dependency on `bindgen` by adding it to the
 
 ```toml
 [build-dependencies]
-bindgen = "0.23"
+bindgen = "0.26.3"
 ```

--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -5,7 +5,7 @@ This can be used to generate code at compile time.
 And of course in our case, we will be generating Rust FFI
 bindings to `bzip2` at compile time. The resulting bindings will be written to
 `$OUT_DIR/bindings.rs` where `$OUT_DIR` is chosen by `cargo` and is something
-like `./target/debug/build/libbindgen-tutorial-bzip2-sys-afc7747d7eafd720/out/`.
+like `./target/debug/build/bindgen-tutorial-bzip2-sys-afc7747d7eafd720/out/`.
 
 ```rust,ignore
 extern crate bindgen;

--- a/book/src/tutorial-4.md
+++ b/book/src/tutorial-4.md
@@ -18,7 +18,7 @@ We can run `cargo build` again to check that the bindings themselves compile:
 
 ```bash
 $ cargo build
-   Compiling libbindgen-tutorial-bzip2-sys v0.1.0
+   Compiling bindgen-tutorial-bzip2-sys v0.1.0
     Finished debug [unoptimized + debuginfo] target(s) in 62.8 secs
 ```
 
@@ -27,7 +27,7 @@ our generated Rust FFI structs match what `bindgen` thinks they should be:
 
 ```bash
 $ cargo test
-   Compiling libbindgen-tutorial-bzip2-sys v0.1.0
+   Compiling bindgen-tutorial-bzip2-sys v0.1.0
     Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
      Running target/debug/deps/bzip2_sys-10413fc2af207810
 
@@ -49,7 +49,7 @@ test bindgen_test_layout__opaque_pthread_t ... ok
 
 test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured
 
-   Doc-tests libbindgen-tutorial-bzip2-sys
+   Doc-tests bindgen-tutorial-bzip2-sys
 
 running 0 tests
 

--- a/book/src/tutorial-5.md
+++ b/book/src/tutorial-5.md
@@ -114,9 +114,9 @@ properly!
 
 ```bash
 $ cargo test
-   Compiling libbindgen-tutorial-bzip2-sys v0.1.0
+   Compiling bindgen-tutorial-bzip2-sys v0.1.0
     Finished debug [unoptimized + debuginfo] target(s) in 0.54 secs
-     Running target/debug/deps/libbindgen_tutorial_bzip2_sys-1c5626bbc4401c3a
+     Running target/debug/deps/bindgen_tutorial_bzip2_sys-1c5626bbc4401c3a
 
 running 15 tests
 test bindgen_test_layout___darwin_pthread_handler_rec ... ok
@@ -161,7 +161,7 @@ test tests::round_trip_compression_decompression ... ok
 
 test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured
 
-   Doc-tests libbindgen-tutorial-bzip2-sys
+   Doc-tests bindgen-tutorial-bzip2-sys
 
 running 0 tests
 

--- a/book/src/tutorial-6.md
+++ b/book/src/tutorial-6.md
@@ -10,4 +10,4 @@ Check out the [full code on Github!][example]
 
 [bz-sys]: https://crates.io/crates/bzip2-sys
 [bz]: https://crates.io/crates/bzip2
-[example]: https://github.com/fitzgen/libbindgen-tutorial-bzip2-sys
+[example]: https://github.com/fitzgen/bindgen-tutorial-bzip2-sys


### PR DESCRIPTION
This also removes old references to `libbindgen` and replaces them with
`bindgen`. I renamed the repo containing the tutorial's full code, so those
github links should work, and this isn't just an artifact of a blind
search/replace.

Part of #803 