### PR TITLE
Document -x c++, not -x=c++

### DIFF
--- a/book/src/cpp.md
+++ b/book/src/cpp.md
@@ -17,7 +17,7 @@ of them in a type it is generating bindings for:
 * SFINAE
 
 When passing in header files, the file will automatically be treated as C++ if
-it ends in `.hpp`. If it doesn't, adding `-x=c++` clang args can be used to
+it ends in `.hpp`. If it doesn't, adding `-x c++` clang args can be used to
 force C++ mode. You probably also want to use `-std=c++14` or similar clang args
 as well.
 


### PR DESCRIPTION
When using -x=c++ in bindgen arguments, we hit #340. We should use -x c++ instead.