### PR TITLE
Preserve comments when dumping preprocessed input headers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,11 @@
 // files, and therefore any `#include` harms reproducibility. Additionally,
 // the test case isn't minimal since the included file almost assuredly
 // contains things that aren't necessary to reproduce the bug, and makes
-// tracking it down much more difficult. If necessary, see
+// tracking it down much more difficult.
+//
+// Use the `--dump-preprocessed-input` flag or the
+// `bindgen::Builder::dump_preprocessed_input` method to make your test case
+// standalone and without `#include`s, and then use C-Reduce to minimize it:
 // https://github.com/servo/rust-bindgen/blob/master/CONTRIBUTING.md#using-creduce-to-minimize-test-cases
 ```
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -63,8 +63,8 @@ bindings is missing a field that exists in the C/C++ struct, note that here.
 <details>
 
 ```
-Insert debug logging when running bindgen with the `RUST_LOG=bindgen` environment
-variable set.
+Insert debug logging when running bindgen (not when compiling bindgen's output)
+with the `RUST_LOG=bindgen` environment variable set.
 ```
 
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,11 +283,6 @@ Afterwards, there should be a `__bindgen.i` or `__bindgen.ii` file containing
 the combined and preprocessed input headers, which is usable as an isolated,
 standalone test case.
 
-Note that the preprocessor likely removed all comments, so if the bug you're
-trying to pin down involves source annotations (for example, `/** <div
-rustbindgen opaque> */`), then you will have to manually reapply them to the
-preprocessed file.
-
 ### Writing a Predicate Script
 
 Writing a `predicate.sh` script for a `bindgen` test case is fairly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,10 +881,6 @@ impl Builder {
         }
 
         let mut child = cmd.spawn()?;
-        if !child.wait()?.success() {
-            return Err(io::Error::new(io::ErrorKind::Other,
-                                      "clang exited with non-zero status"));
-        }
 
         let mut preprocessed = child.stdout.take().unwrap();
         let mut file = File::create(if is_cpp {
@@ -893,7 +889,13 @@ impl Builder {
             "__bindgen.i"
         })?;
         io::copy(&mut preprocessed, &mut file)?;
-        Ok(())
+
+        if child.wait()?.success() {
+            Ok(())
+        } else {
+            Err(io::Error::new(io::ErrorKind::Other,
+                               "clang exited with non-zero status"))
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ use std::fs::{File, OpenOptions};
 use std::iter;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 use syntax::ast;
@@ -870,19 +870,30 @@ impl Builder {
 
         let mut cmd = Command::new(&clang.path);
         cmd.arg("-save-temps")
+            .arg("-E")
+            .arg("-C")
             .arg("-c")
-            .arg(&wrapper_path);
+            .arg(&wrapper_path)
+            .stdout(Stdio::piped());
 
         for a in &self.options.clang_args {
             cmd.arg(a);
         }
 
-        if cmd.spawn()?.wait()?.success() {
-            Ok(())
-        } else {
-            Err(io::Error::new(io::ErrorKind::Other,
-                               "clang exited with non-zero status"))
+        let mut child = cmd.spawn()?;
+        if !child.wait()?.success() {
+            return Err(io::Error::new(io::ErrorKind::Other,
+                                      "clang exited with non-zero status"));
         }
+
+        let mut preprocessed = child.stdout.take().unwrap();
+        let mut file = File::create(if is_cpp {
+            "__bindgen.ii"
+        } else {
+            "__bindgen.i"
+        })?;
+        io::copy(&mut preprocessed, &mut file)?;
+        Ok(())
     }
 }
 

--- a/tests/headers/arg_keyword.hpp
+++ b/tests/headers/arg_keyword.hpp
@@ -1,1 +1,3 @@
+// This comment exists to ensure that `--dump-preprocessed-input` doesn't strip
+// comments.
 void foo(const char* type);


### PR DESCRIPTION
It should be really easy to generate standalone, isolated test cases for bindgen bugs now \o/

See each commit for further details.

r? @emilio 