### PR TITLE
Use fix point analysis to implement can_derive_debug

### DIFF
--- a/src/ir/cant_derive_debug.rs
+++ b/src/ir/cant_derive_debug.rs
@@ -1,0 +1,303 @@
+//! Determining which types for which we can emit `#[derive(Debug)]`.
+use super::analysis::MonotoneFramework;
+use ir::context::{BindgenContext, ItemId};
+use ir::item::ItemSet;
+use std::collections::HashSet;
+use std::collections::HashMap;
+use ir::traversal::EdgeKind;
+use ir::ty::RUST_DERIVE_IN_ARRAY_LIMIT;
+use ir::ty::TypeKind;
+use ir::comp::Field;
+use ir::traversal::Trace;
+use ir::comp::FieldMethods;
+use ir::layout::Layout;
+use ir::derive::CanTriviallyDeriveDebug;
+use ir::comp::CompKind;
+
+/// An analysis that finds for each IR item whether debug cannot be derived.
+///
+/// We use the monotone constraint function `cant_derive_debug`, defined as
+/// follows:
+///
+/// * If T is Opaque and layout of the type is known, get this layout as opaque
+///   type and check whether it can be derived using trivial checks.
+/// * If T is Array type, debug cannot be derived if the length of the array is
+///   larger than the limit or the type of data the array contains cannot derive
+///   debug.
+/// * If T is a type alias, a templated alias or an indirection to another type,
+///   debug cannot be derived if the type T refers to cannot be derived debug.
+/// * If T is a compound type, debug cannot be derived if any of its base member
+///   or field cannot be derived debug.
+/// * If T is a pointer, T cannot be derived debug if T is a function pointer
+///   and the function signature cannot be derived debug.
+/// * If T is an instantiation of an abstract template definition, T cannot be
+///   derived debug if any of the template arguments or template definition
+///   cannot derive debug.
+#[derive(Debug, Clone)]
+pub struct CantDeriveDebugAnalysis<'ctx, 'gen>
+    where 'gen: 'ctx
+{
+    ctx: &'ctx BindgenContext<'gen>,
+
+    // The incremental result of this analysis's computation. Everything in this
+    // set cannot derive debug.
+    cant_derive_debug: HashSet<ItemId>,
+
+    // Dependencies saying that if a key ItemId has been inserted into the
+    // `cant_derive_debug` set, then each of the ids in Vec<ItemId> need to be
+    // considered again.
+    //
+    // This is a subset of the natural IR graph with reversed edges, where we
+    // only include the edges from the IR graph that can affect whether a type
+    // can derive debug or not.
+    dependencies: HashMap<ItemId, Vec<ItemId>>,
+}
+
+impl<'ctx, 'gen> CantDeriveDebugAnalysis<'ctx, 'gen> {
+    fn consider_edge(kind: EdgeKind) -> bool {
+        match kind {
+            // These are the only edges that can affect whether a type can derive
+            // debug or not.
+            EdgeKind::BaseMember |
+            EdgeKind::Field |
+            EdgeKind::TypeReference |
+            EdgeKind::VarType |
+            EdgeKind::TemplateArgument |
+            EdgeKind::TemplateDeclaration |
+            EdgeKind::TemplateParameterDefinition => true,
+
+            EdgeKind::Constructor |
+            EdgeKind::FunctionReturn |
+            EdgeKind::FunctionParameter |
+            EdgeKind::InnerType |
+            EdgeKind::InnerVar |
+            EdgeKind::Method => false,
+            EdgeKind::Generic => false,
+        }
+    }
+
+    fn insert(&mut self, id: ItemId) -> bool {
+        let was_already_in = self.cant_derive_debug.insert(id);
+        assert!(
+            was_already_in,
+            format!("We shouldn't try and insert twice because if it was already in the set, \
+             `constrain` would have exited early.: {:?}", id)
+        );
+        true
+    }
+}
+
+impl<'ctx, 'gen> MonotoneFramework for CantDeriveDebugAnalysis<'ctx, 'gen> {
+    type Node = ItemId;
+    type Extra = &'ctx BindgenContext<'gen>;
+    type Output = HashSet<ItemId>;
+
+    fn new(ctx: &'ctx BindgenContext<'gen>) -> CantDeriveDebugAnalysis<'ctx, 'gen> {
+        let cant_derive_debug = HashSet::new();
+        let mut dependencies = HashMap::new();
+        let whitelisted_items: HashSet<_> = ctx.whitelisted_items().collect();
+
+        let whitelisted_and_blacklisted_items: ItemSet = whitelisted_items.iter()
+            .cloned()
+            .flat_map(|i| {
+                let mut reachable = vec![i];
+                i.trace(ctx, &mut |s, _| {
+                    reachable.push(s);
+                }, &());
+                reachable
+            })
+            .collect();
+
+        for item in whitelisted_and_blacklisted_items {
+            dependencies.entry(item).or_insert(vec![]);
+
+            {
+                // We reverse our natural IR graph edges to find dependencies
+                // between nodes.
+                item.trace(ctx, &mut |sub_item: ItemId, edge_kind| {
+                    if Self::consider_edge(edge_kind) {
+                        dependencies.entry(sub_item)
+                            .or_insert(vec![])
+                            .push(item);
+                    }
+                }, &());
+            }
+        }
+
+        CantDeriveDebugAnalysis {
+            ctx: ctx,
+            cant_derive_debug: cant_derive_debug,
+            dependencies: dependencies,
+        }
+    }
+
+    fn initial_worklist(&self) -> Vec<ItemId> {
+        self.ctx.whitelisted_items().collect()
+    }
+
+    fn constrain(&mut self, id: ItemId) -> bool {
+        if self.cant_derive_debug.contains(&id) {
+            return false;
+        }
+
+        let item = self.ctx.resolve_item(id);
+        let ty = match item.as_type() {
+            None => return false,
+            Some(ty) => ty
+        };
+
+        match *ty.kind() {
+            // handle the simple case
+            // These can derive debug without further information
+            TypeKind::Void |
+            TypeKind::NullPtr |
+            TypeKind::Int(..) |
+            TypeKind::Float(..) |
+            TypeKind::Complex(..) |
+            TypeKind::Function(..) |
+            TypeKind::Enum(..) |
+            TypeKind::Reference(..) |
+            TypeKind::BlockPointer |
+            TypeKind::Named |
+            TypeKind::UnresolvedTypeRef(..) |
+            TypeKind::ObjCInterface(..) |
+            TypeKind::ObjCId |
+            TypeKind::ObjCSel => {
+                return false;
+            },
+            TypeKind::Opaque => {
+                if ty.layout(self.ctx)
+                    .map_or(true, |l| l.opaque().can_trivially_derive_debug(self.ctx, ())) {
+                        return false;
+                    } else {
+                        return self.insert(id);
+                    }
+            },
+            TypeKind::Array(t, len) => {
+                if len <= RUST_DERIVE_IN_ARRAY_LIMIT {
+                    if self.cant_derive_debug.contains(&t) {
+                        return self.insert(id);
+                    }
+                    return false;
+                } else {
+                    return self.insert(id);
+                }
+            },
+            TypeKind::ResolvedTypeRef(t) |
+            TypeKind::TemplateAlias(t, _) |
+            TypeKind::Alias(t) => {
+                if self.cant_derive_debug.contains(&t) {
+                    return self.insert(id);
+                }
+                return false;
+            },
+            TypeKind::Comp(ref info) => {
+                if info.has_non_type_template_params() {
+                    if ty.layout(self.ctx).map_or(true,
+                                                  |l| l.opaque().can_trivially_derive_debug(self.ctx, ())) {
+                        return false;
+                    } else {
+                        return self.insert(id);
+                    }
+                }
+                if info.kind() == CompKind::Union {
+                    if self.ctx.options().unstable_rust {
+                        return self.insert(id);
+                    }
+
+                    if ty.layout(self.ctx).map_or(true,
+                                                  |l| l.opaque().can_trivially_derive_debug(self.ctx, ())) {
+                        return false;
+                    } else {
+                        return self.insert(id);
+                    }
+                }
+                let bases_cant_derive = info.base_members()
+                    .iter()
+                    .any(|base| self.cant_derive_debug.contains(&base.ty));
+                if bases_cant_derive {
+                    return self.insert(id);
+                }
+                let fields_cant_derive = info.fields()
+                    .iter()
+                    .any(|f| {
+                        match f {
+                            &Field::DataMember(ref data) => self.cant_derive_debug.contains(&data.ty()),
+                            &Field::Bitfields(ref bfu) => bfu.bitfields()
+                                .iter().any(|b| {
+                                    self.cant_derive_debug.contains(&b.ty())
+                                })
+                        }
+                    });
+                if fields_cant_derive {
+                    return self.insert(id);
+                }
+                false
+            },
+            TypeKind::Pointer(inner) => {
+                let inner_type = self.ctx.resolve_type(inner);
+                if let TypeKind::Function(ref sig) =
+                    *inner_type.canonical_type(self.ctx).kind() {
+                        if sig.can_trivially_derive_debug(&self.ctx, ()) {
+                            return false;
+                        } else {
+                            return self.insert(id);
+                        }
+                    }
+                false
+            },
+            TypeKind::TemplateInstantiation(ref template) => {
+                let args_cant_derive = template.template_arguments()
+                    .iter()
+                    .any(|arg| self.cant_derive_debug.contains(&arg));
+                if args_cant_derive {
+                    return self.insert(id);
+                }
+                let ty_cant_derive = template.template_definition()
+                    .into_resolver()
+                    .through_type_refs()
+                    .through_type_aliases()
+                    .resolve(self.ctx)
+                    .as_type()
+                    .expect("Instantiations of a non-type?")
+                    .as_comp()
+                    .and_then(|c| {
+                        // For non-type template parameters, we generate an opaque
+                        // blob, and in this case the instantiation has a better
+                        // idea of the layout than the definition does.
+                        if c.has_non_type_template_params() {
+                            let opaque = ty.layout(self.ctx)
+                                .or_else(|| self.ctx.resolve_type(template.template_definition()).layout(self.ctx))
+                                .unwrap_or(Layout::zero())
+                                .opaque();
+                            Some(!opaque.can_trivially_derive_debug(&self.ctx, ()))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| self.cant_derive_debug.contains(&template.template_definition()));
+                if ty_cant_derive {
+                    return self.insert(id);
+                }
+                false
+            },
+        }
+    }
+
+    fn each_depending_on<F>(&self, id: ItemId, mut f: F)
+        where F: FnMut(ItemId),
+    {
+        if let Some(edges) = self.dependencies.get(&id) {
+            for item in edges {
+                trace!("enqueue {:?} into worklist", item);
+                f(*item);
+            }
+        }
+    }
+}
+
+impl<'ctx, 'gen> From<CantDeriveDebugAnalysis<'ctx, 'gen>> for HashSet<ItemId> {
+    fn from(analysis: CantDeriveDebugAnalysis<'ctx, 'gen>) -> Self {
+        analysis.cant_derive_debug
+    }
+}

--- a/src/ir/derive.rs
+++ b/src/ir/derive.rs
@@ -23,6 +23,23 @@ pub trait CanDeriveDebug {
                         -> bool;
 }
 
+/// A trait that encapsulates the logic for whether or not we can derive `Debug`.
+/// The difference between this trait and the CanDeriveDebug is that the type
+/// implementing this trait cannot use recursion or lookup result from fix point
+/// analysis. It's a helper trait for fix point analysis.
+pub trait CanTriviallyDeriveDebug {
+
+    /// Serve the same purpose as the Extra in CanDeriveDebug.
+    type Extra;
+
+    /// Return `true` if `Debug` can be derived for this thing, `false`
+    /// otherwise.
+    fn can_trivially_derive_debug(&self,
+                        ctx: &BindgenContext,
+                        extra: Self::Extra)
+                        -> bool;
+}
+
 /// A trait that encapsulates the logic for whether or not we can derive `Copy`
 /// for a given thing.
 pub trait CanDeriveCopy<'a> {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -7,7 +7,7 @@ use super::traversal::{EdgeKind, Trace, Tracer};
 use super::ty::TypeKind;
 use clang;
 use clang_sys::CXCallingConv;
-use ir::derive::CanDeriveDebug;
+use ir::derive::CanTriviallyDeriveDebug;
 use parse::{ClangItemParser, ClangSubItemParser, ParseError, ParseResult};
 use std::io;
 use syntax::abi;
@@ -440,10 +440,10 @@ impl Trace for FunctionSig {
 // and https://github.com/rust-lang/rust/issues/40158
 //
 // Note that copy is always derived, so we don't need to implement it.
-impl CanDeriveDebug for FunctionSig {
+impl CanTriviallyDeriveDebug for FunctionSig {
     type Extra = ();
 
-    fn can_derive_debug(&self, _ctx: &BindgenContext, _: ()) -> bool {
+    fn can_trivially_derive_debug(&self, _ctx: &BindgenContext, _: ()) -> bool {
         const RUST_DERIVE_FUNPTR_LIMIT: usize = 12;
         if self.argument_types.len() > RUST_DERIVE_FUNPTR_LIMIT {
             return false;

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -272,28 +272,7 @@ impl CanDeriveDebug for Item {
     type Extra = ();
 
     fn can_derive_debug(&self, ctx: &BindgenContext, _: ()) -> bool {
-        if self.detect_derive_debug_cycle.get() {
-            return true;
-        }
-
-        self.detect_derive_debug_cycle.set(true);
-
-        let result = ctx.options().derive_debug &&
-                     match self.kind {
-            ItemKind::Type(ref ty) => {
-                if self.is_opaque(ctx, &()) {
-                    ty.layout(ctx)
-                        .map_or(true, |l| l.opaque().can_derive_debug(ctx, ()))
-                } else {
-                    ty.can_derive_debug(ctx, ())
-                }
-            }
-            _ => false,
-        };
-
-        self.detect_derive_debug_cycle.set(false);
-
-        result
+        ctx.options().derive_debug && ctx.lookup_item_id_can_derive_debug(self.id())
     }
 }
 

--- a/src/ir/layout.rs
+++ b/src/ir/layout.rs
@@ -1,7 +1,7 @@
 //! Intermediate representation for the physical layout of some type.
 
 use super::context::BindgenContext;
-use super::derive::{CanDeriveCopy, CanDeriveDebug, CanDeriveDefault};
+use super::derive::{CanDeriveCopy, CanTriviallyDeriveDebug, CanDeriveDefault};
 use super::ty::{RUST_DERIVE_IN_ARRAY_LIMIT, Type, TypeKind};
 use clang;
 use std::{cmp, mem};
@@ -102,10 +102,10 @@ impl Opaque {
     }
 }
 
-impl CanDeriveDebug for Opaque {
+impl CanTriviallyDeriveDebug for Opaque {
     type Extra = ();
 
-    fn can_derive_debug(&self, _: &BindgenContext, _: ()) -> bool {
+    fn can_trivially_derive_debug(&self, _: &BindgenContext, _: ()) -> bool {
         self.array_size()
             .map_or(false, |size| size <= RUST_DERIVE_IN_ARRAY_LIMIT)
     }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -23,3 +23,4 @@ pub mod traversal;
 pub mod ty;
 pub mod var;
 pub mod objc;
+pub mod cant_derive_debug;

--- a/src/ir/traversal.rs
+++ b/src/ir/traversal.rs
@@ -58,7 +58,7 @@ pub enum EdgeKind {
     /// template<typename T>
     /// class Foo { };
     ///
-    /// using Bar = Foo<int>;
+    /// using Bar = Foo<ant>;
     /// ```
     TemplateDeclaration,
 

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -539,35 +539,10 @@ impl TemplateParameters for TypeKind {
 }
 
 impl CanDeriveDebug for Type {
-    type Extra = ();
+    type Extra = Item;
 
-    fn can_derive_debug(&self, ctx: &BindgenContext, _: ()) -> bool {
-        match self.kind {
-            TypeKind::Array(t, len) => {
-                len <= RUST_DERIVE_IN_ARRAY_LIMIT && t.can_derive_debug(ctx, ())
-            }
-            TypeKind::ResolvedTypeRef(t) |
-            TypeKind::TemplateAlias(t, _) |
-            TypeKind::Alias(t) => t.can_derive_debug(ctx, ()),
-            TypeKind::Comp(ref info) => {
-                info.can_derive_debug(ctx, self.layout(ctx))
-            }
-            TypeKind::Pointer(inner) => {
-                let inner = ctx.resolve_type(inner);
-                if let TypeKind::Function(ref sig) =
-                    *inner.canonical_type(ctx).kind() {
-                    return sig.can_derive_debug(ctx, ());
-                }
-                return true;
-            }
-            TypeKind::TemplateInstantiation(ref inst) => {
-                inst.can_derive_debug(ctx, self.layout(ctx))
-            }
-            TypeKind::Opaque => {
-                self.layout.map_or(true, |l| l.opaque().can_derive_debug(ctx, ()))
-            }
-            _ => true,
-        }
+    fn can_derive_debug(&self, ctx: &BindgenContext, item: Item) -> bool {
+        ctx.lookup_item_id_can_derive_debug(item.id())
     }
 }
 


### PR DESCRIPTION
It's failing about 30 tests now and most of them is related to template. I'm also not so sure about the place to call compute_can_derive_debug in gen. 
Fix: #767 

r? @fitzgen 