### PR TITLE
Speed up CI runs by only `cargo check`ing for docs

### DIFF
--- a/ci/assert-docs.sh
+++ b/ci/assert-docs.sh
@@ -3,4 +3,4 @@
 set -xeu
 cd "$(dirname "$0")/.."
 
-cargo build --features "$BINDGEN_FEATURES testing_only_docs"
+cargo check --features "$BINDGEN_FEATURES testing_only_docs"


### PR DESCRIPTION
Running `cargo check --features testing_only_docs` will catch missing doc
comments, and we can avoid doing a full build.

r? @emilio 