### PR TITLE
Have tests pass on Windows

### DIFF
--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -9,9 +9,92 @@ extern "C" {
                                                               ::std::os::raw::c_int)
                                          -> ::std::os::raw::c_int>;
 }
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Foo { Bar = 0, Qux = 1, }
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Neg { MinusOne = -1, One = 1, }
+pub type Char = ::std::os::raw::c_char;
+pub type SChar = ::std::os::raw::c_schar;
+pub type UChar = ::std::os::raw::c_uchar;
+#[repr(C)]
+#[derive(Debug, Copy)]
+pub struct Test {
+    pub ch: ::std::os::raw::c_char,
+    pub u: ::std::os::raw::c_uchar,
+    pub d: ::std::os::raw::c_schar,
+    pub cch: ::std::os::raw::c_char,
+    pub cu: ::std::os::raw::c_uchar,
+    pub cd: ::std::os::raw::c_schar,
+    pub Cch: Char,
+    pub Cu: UChar,
+    pub Cd: SChar,
+    pub Ccch: Char,
+    pub Ccu: UChar,
+    pub Ccd: SChar,
+}
+#[test]
+fn bindgen_test_layout_Test() {
+    assert_eq!(::std::mem::size_of::<Test>() , 12usize , concat ! (
+               "Size of: " , stringify ! ( Test ) ));
+    assert_eq! (::std::mem::align_of::<Test>() , 1usize , concat ! (
+                "Alignment of " , stringify ! ( Test ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . ch as * const _ as usize } ,
+                0usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( ch ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . u as * const _ as usize } ,
+                1usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( u ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . d as * const _ as usize } ,
+                2usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( d ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . cch as * const _ as usize } ,
+                3usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( cch ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . cu as * const _ as usize } ,
+                4usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( cu ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . cd as * const _ as usize } ,
+                5usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( cd ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . Cch as * const _ as usize } ,
+                6usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( Cch ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . Cu as * const _ as usize } ,
+                7usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( Cu ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . Cd as * const _ as usize } ,
+                8usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( Cd ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . Ccch as * const _ as usize } ,
+                9usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( Ccch ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . Ccu as * const _ as usize } ,
+                10usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( Ccu ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const Test ) ) . Ccd as * const _ as usize } ,
+                11usize , concat ! (
+                "Alignment of field: " , stringify ! ( Test ) , "::" ,
+                stringify ! ( Ccd ) ));
+}
+impl Clone for Test {
+    fn clone(&self) -> Self { *self }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,6 @@ use bindgen::{Builder, builder, clang_version};
 use std::fs;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Read, Write};
 use std::path::PathBuf;
-use std::process::Command;
 
 #[path="../src/options.rs"]
 mod options;
@@ -243,7 +242,11 @@ fn test_multiple_header_calls_in_builder() {
 }
 
 #[test]
+// Doesn't support executing sh file on Windows.
+// We may want to implement it in Rust so that we support all systems.
+#[cfg(not(target_os = "windows"))]
 fn no_system_header_includes() {
+    use std::process::Command;
     assert!(Command::new("./ci/no-includes.sh")
             .current_dir(env!("CARGO_MANIFEST_DIR"))
             .spawn()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -219,7 +219,7 @@ extern \"C\" {
 fn test_multiple_header_calls_in_builder() {
     let actual = builder()
         .header(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/headers/func_ptr.h"))
-        .header(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/headers/enum.h"))
+        .header(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/headers/char.h"))
         .generate()
         .unwrap()
         .to_string();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -137,6 +137,20 @@ fn create_bindgen_builder(header: &PathBuf) -> Result<Option<Builder>, Error> {
         }
     }
 
+    // Windows platform has various different conventions than *nix platforms,
+    // e.g. default enum underlying type, struct padding, mangling. Most tests
+    // were written and checked on Linux and macOS, and thus they could fail on
+    // Windows. We just make those tests targetting Linux instead as far as one
+    // isn't annotated for a specific target.
+    if cfg!(target_os = "windows") {
+        if flags.iter().all(|flag| !flag.starts_with("--target=")) {
+            if !flags.iter().any(|flag| flag == "--") {
+                flags.push("--".into());
+            }
+            flags.push("--target=x86_64-unknown-linux".into());
+        }
+    }
+
     // Fool builder_from_flags() into believing it has real env::args_os...
     // - add "bindgen" as executable name 0th element
     // - add header filename as 1st element


### PR DESCRIPTION
These changes allow `cargo test` to pass on Windows.

There are two followup work we should do at some point:
* setup AppVeyor so that we don't break Windows development either
* convert `no_system_header_includes` to be pure Rust so that it supports Windows natively