### PR TITLE
Use fully disambiguated name instead of a number for layout tests (fixes #394)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -768,7 +768,7 @@ impl CodeGenerator for TemplateInstantiation {
             let size = layout.size;
             let align = layout.align;
 
-            let name = item.canonical_name(ctx);
+            let name = item.full_disambiguated_name(ctx);
             let mut fn_name = format!("__bindgen_test_layout_{}_instantiation", name);
             let times_seen = result.overload_number(&fn_name);
             if times_seen > 0 {

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -681,6 +681,33 @@ impl Item {
         }
     }
 
+    /// Create a fully disambiguated name for an item, including template
+    /// parameters if it is a type
+    pub fn full_disambiguated_name(&self, ctx: &BindgenContext) -> String {
+        let mut s = String::new();
+        let level = 0;
+        self.push_disambiguated_name(ctx, &mut s, level);
+        s
+    }
+
+    /// Helper function for full_disambiguated_name
+    fn push_disambiguated_name(&self, ctx: &BindgenContext, to: &mut String, level: u8) {
+        to.push_str(&self.canonical_name(ctx));
+        if let ItemKind::Type(ref ty) = *self.kind() {
+            if let TypeKind::TemplateInstantiation(ref inst) = *ty.kind() {
+                to.push_str(&format!("_open{}_", level));
+                for arg in inst.template_arguments() {
+                    arg.into_resolver()
+                       .through_type_refs()
+                       .resolve(ctx)
+                       .push_disambiguated_name(ctx, to, level + 1);
+                    to.push_str("_");
+                }
+                to.push_str(&format!("close{}", level));
+            }
+        }
+    }
+
     /// Get this function item's name, or `None` if this item is not a function.
     fn func_name(&self) -> Option<&str> {
         match *self.kind() {

--- a/tests/expectations/tests/anon_union.rs
+++ b/tests/expectations/tests/anon_union.rs
@@ -80,7 +80,7 @@ impl Default for ErrorResult {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_TErrorResult_instantiation() {
+fn __bindgen_test_layout_TErrorResult_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<TErrorResult>() , 24usize , concat ! (
                "Size of template specialization: " , stringify ! (
                TErrorResult ) ));

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -78,7 +78,7 @@ extern "C" {
     pub static mut var: A_B;
 }
 #[test]
-fn __bindgen_test_layout_A_D_instantiation() {
+fn __bindgen_test_layout_A_D_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<A_D<::std::os::raw::c_int>>() , 4usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -35,7 +35,7 @@ impl Default for WithoutDtor {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_HandleWithDtor_instantiation() {
+fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>()
                , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/crtp.rs
+++ b/tests/expectations/tests/crtp.rs
@@ -51,7 +51,7 @@ impl Default for DerivedFromBaseWithDestructor {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Base_instantiation() {
+fn __bindgen_test_layout_Base_open0_Derived_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Base>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( Base ) ));
     assert_eq!(::std::mem::align_of::<Base>() , 1usize , concat ! (
@@ -59,7 +59,7 @@ fn __bindgen_test_layout_Base_instantiation() {
                ));
 }
 #[test]
-fn __bindgen_test_layout_BaseWithDestructor_instantiation() {
+fn __bindgen_test_layout_BaseWithDestructor_open0_DerivedFromBaseWithDestructor_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<BaseWithDestructor>() , 1usize , concat !
                (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/default-template-parameter.rs
+++ b/tests/expectations/tests/default-template-parameter.rs
@@ -16,7 +16,7 @@ impl <T, U> Default for Foo<T, U> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Foo_instantiation() {
+fn __bindgen_test_layout_Foo_open0_bool__int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Foo<bool, ::std::os::raw::c_int>>() ,
                8usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -42,7 +42,7 @@ impl Default for Bar {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_RefPtr_instantiation() {
+fn __bindgen_test_layout_RefPtr_open0_Foo_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<RefPtr<Foo>>() , 8usize , concat ! (
                "Size of template specialization: " , stringify ! ( RefPtr<Foo>
                ) ));

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -37,7 +37,7 @@ impl Default for InstantiateIt {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_LinkedList_instantiation() {
+fn __bindgen_test_layout_LinkedList_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<LinkedList>() , 16usize , concat ! (
                "Size of template specialization: " , stringify ! ( LinkedList
                ) ));

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -102,7 +102,7 @@ pub mod root {
         fn default() -> Self { unsafe { ::std::mem::zeroed() } }
     }
     #[test]
-    fn __bindgen_test_layout_C_instantiation() {
+    fn __bindgen_test_layout_C_open0_n_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<[u64; 33usize]>() , 264usize , concat
                    ! (
                    "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -32,7 +32,7 @@ impl Default for JS_AutoIdVector {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_JS_Base_instantiation() {
+fn __bindgen_test_layout_JS_Base_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<JS_Base>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( JS_Base )
                ));

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -29,7 +29,7 @@ impl Default for AutoIdVector {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Outer_instantiation() {
+fn __bindgen_test_layout_Outer_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Outer>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( Outer ) ));
     assert_eq!(::std::mem::align_of::<Outer>() , 1usize , concat ! (

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -37,7 +37,7 @@ extern "C" {
     pub static mut AutoIdVector: _bindgen_ty_1;
 }
 #[test]
-fn __bindgen_test_layout_a_instantiation() {
+fn __bindgen_test_layout_a_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<a>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( a ) ));
     assert_eq!(::std::mem::align_of::<a>() , 1usize , concat ! (

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -80,7 +80,7 @@ extern "C" {
     pub fn Servo_Element_GetSnapshot() -> A;
 }
 #[test]
-fn __bindgen_test_layout_f_instantiation() {
+fn __bindgen_test_layout_f_open0_e_open1_int_close1_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<f>() , 1usize , concat ! (
                "Size of template specialization: " , stringify ! ( f ) ));
     assert_eq!(::std::mem::align_of::<f>() , 1usize , concat ! (

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -67,7 +67,7 @@ pub mod root {
         pub _address: u8,
     }
     #[test]
-    fn __bindgen_test_layout_StaticRefPtr_instantiation() {
+    fn __bindgen_test_layout_StaticRefPtr_open0_B_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::StaticRefPtr>() , 1usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -51,7 +51,7 @@ impl Default for ServoElementSnapshotTable {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Set_instantiation() {
+fn __bindgen_test_layout_Set_open0_VirtualMethods_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Set>() , 4usize , concat ! (
                "Size of template specialization: " , stringify ! ( Set ) ));
     assert_eq!(::std::mem::align_of::<Set>() , 4usize , concat ! (

--- a/tests/expectations/tests/libclang-3.8/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-3.8/issue-769-bad-instantiation-test.rs
@@ -18,7 +18,7 @@ pub mod root {
         fn default() -> Self { unsafe { ::std::mem::zeroed() } }
     }
     #[test]
-    fn __bindgen_test_layout_Rooted_instantiation() {
+    fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>()
                    , 4usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -29,7 +29,7 @@ pub mod root {
                    root::Rooted<::std::os::raw::c_int> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Rooted_instantiation_1() {
+    fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation_1() {
         assert_eq!(::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>()
                    , 4usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/libclang-3.8/partial-specialization-and-inheritance.rs
+++ b/tests/expectations/tests/libclang-3.8/partial-specialization-and-inheritance.rs
@@ -46,7 +46,7 @@ impl Usage {
     }
 }
 #[test]
-fn __bindgen_test_layout__bindgen_ty_id_21_instantiation() {
+fn __bindgen_test_layout__bindgen_ty_id_21_open0__bindgen_ty_id_19_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u32; 2usize]>() , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 2usize] ) ));

--- a/tests/expectations/tests/libclang-3.9/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-3.9/issue-769-bad-instantiation-test.rs
@@ -18,7 +18,7 @@ pub mod root {
         fn default() -> Self { unsafe { ::std::mem::zeroed() } }
     }
     #[test]
-    fn __bindgen_test_layout_Rooted_instantiation() {
+    fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>()
                    , 4usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -29,7 +29,7 @@ pub mod root {
                    root::Rooted<::std::os::raw::c_int> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Rooted_instantiation_1() {
+    fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation_1() {
         assert_eq!(::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>()
                    , 4usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/libclang-3.9/partial-specialization-and-inheritance.rs
+++ b/tests/expectations/tests/libclang-3.9/partial-specialization-and-inheritance.rs
@@ -34,7 +34,7 @@ impl Clone for Usage {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn __bindgen_test_layout__bindgen_ty_id_20_instantiation() {
+fn __bindgen_test_layout__bindgen_ty_id_20_open0__bindgen_ty_id_18_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u32; 2usize]>() , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 2usize] ) ));

--- a/tests/expectations/tests/libclang-4/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-4/issue-769-bad-instantiation-test.rs
@@ -19,7 +19,7 @@ pub mod root {
     }
     pub type AutoValueVector_Alias = ::std::os::raw::c_int;
     #[test]
-    fn __bindgen_test_layout_Rooted_instantiation() {
+    fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>()
                    , 4usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -30,7 +30,7 @@ pub mod root {
                    root::Rooted<::std::os::raw::c_int> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Rooted_instantiation_1() {
+    fn __bindgen_test_layout_Rooted_open0_AutoValueVector_Alias_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::Rooted<root::AutoValueVector_Alias>>()
                    , 4usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/libclang-4/partial-specialization-and-inheritance.rs
+++ b/tests/expectations/tests/libclang-4/partial-specialization-and-inheritance.rs
@@ -34,7 +34,7 @@ impl Clone for Usage {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn __bindgen_test_layout__bindgen_ty_id_20_instantiation() {
+fn __bindgen_test_layout__bindgen_ty_id_20_open0__bindgen_ty_id_18_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u32; 2usize]>() , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 2usize] ) ));

--- a/tests/expectations/tests/libclang-4/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-4/type_alias_template_specialized.rs
@@ -30,7 +30,7 @@ impl Default for Rooted {
 /// <div rustbindgen replaces="MaybeWrapped"></div>
 pub type MaybeWrapped<a> = a;
 #[test]
-fn __bindgen_test_layout_MaybeWrapped_instantiation() {
+fn __bindgen_test_layout_MaybeWrapped_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<MaybeWrapped<::std::os::raw::c_int>>() ,
                4usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -38,7 +38,7 @@ impl Default for UsesArray {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Array_instantiation() {
+fn __bindgen_test_layout_Array_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u32; 4usize]>() , 16usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 4usize] ) ));
@@ -47,7 +47,7 @@ fn __bindgen_test_layout_Array_instantiation() {
                [u32; 4usize] ) ));
 }
 #[test]
-fn __bindgen_test_layout_Array_instantiation_1() {
+fn __bindgen_test_layout_Array_open0_char_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u8; 16usize]>() , 16usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u8; 16usize] ) ));
@@ -56,7 +56,7 @@ fn __bindgen_test_layout_Array_instantiation_1() {
                [u8; 16usize] ) ));
 }
 #[test]
-fn __bindgen_test_layout_Array_instantiation_2() {
+fn __bindgen_test_layout_Array_open0_bool__close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u8; 8usize]>() , 8usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u8; 8usize] ) ));

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -115,7 +115,7 @@ pub mod root {
         }
     }
     #[test]
-    fn __bindgen_test_layout_Template_instantiation() {
+    fn __bindgen_test_layout_Template_open0_Foo_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::zoidberg::Template<root::zoidberg::Foo>>()
                    , 1usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -63,7 +63,7 @@ impl Clone for ContainsOpaqueInstantiation {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn __bindgen_test_layout_Template_instantiation() {
+fn __bindgen_test_layout_Template_open0_char_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Template<::std::os::raw::c_char>>() ,
                1usize , concat ! (
                "Size of template specialization: " , stringify ! (

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -64,7 +64,7 @@ impl Default for WithOpaquePtr {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Opaque_instantiation() {
+fn __bindgen_test_layout_Opaque_open0_float_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<u32>() , 4usize , concat ! (
                "Size of template specialization: " , stringify ! ( u32 ) ));
     assert_eq!(::std::mem::align_of::<u32>() , 4usize , concat ! (

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -34,7 +34,7 @@ impl Default for Test {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_nsTArray_instantiation() {
+fn __bindgen_test_layout_nsTArray_open0_long_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<nsTArray>() , 4usize , concat ! (
                "Size of template specialization: " , stringify ! ( nsTArray )
                ));

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -24,7 +24,7 @@ impl Default for C {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Array_instantiation() {
+fn __bindgen_test_layout_Array_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<[u32; 3usize]>() , 12usize , concat ! (
                "Size of template specialization: " , stringify ! (
                [u32; 3usize] ) ));

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -234,7 +234,7 @@ impl <T> Default for ReplacedWithoutDestructorFwd<T> {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_Foo_instantiation() {
+fn __bindgen_test_layout_Foo_open0_int_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Foo<::std::os::raw::c_int>>() , 24usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (
@@ -245,7 +245,7 @@ fn __bindgen_test_layout_Foo_instantiation() {
                Foo<::std::os::raw::c_int> ) ));
 }
 #[test]
-fn __bindgen_test_layout_Foo_instantiation_1() {
+fn __bindgen_test_layout_Foo_open0_int_int_close0_instantiation_1() {
     assert_eq!(::std::mem::size_of::<Foo<::std::os::raw::c_int>>() , 24usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (
@@ -256,7 +256,7 @@ fn __bindgen_test_layout_Foo_instantiation_1() {
                Foo<::std::os::raw::c_int> ) ));
 }
 #[test]
-fn __bindgen_test_layout_Rooted_instantiation() {
+fn __bindgen_test_layout_Rooted_open0__bindgen_ty_id_108_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>() ,
                24usize , concat ! (
                "Size of template specialization: " , stringify ! (
@@ -267,7 +267,7 @@ fn __bindgen_test_layout_Rooted_instantiation() {
                Rooted<*mut ::std::os::raw::c_void> ) ));
 }
 #[test]
-fn __bindgen_test_layout_Rooted_instantiation_1() {
+fn __bindgen_test_layout_Rooted_open0__bindgen_ty_id_114_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>() ,
                24usize , concat ! (
                "Size of template specialization: " , stringify ! (
@@ -278,7 +278,7 @@ fn __bindgen_test_layout_Rooted_instantiation_1() {
                Rooted<*mut ::std::os::raw::c_void> ) ));
 }
 #[test]
-fn __bindgen_test_layout_WithDtor_instantiation() {
+fn __bindgen_test_layout_WithDtor_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<WithDtor<::std::os::raw::c_int>>() ,
                4usize , concat ! (
                "Size of template specialization: " , stringify ! (
@@ -289,7 +289,7 @@ fn __bindgen_test_layout_WithDtor_instantiation() {
                WithDtor<::std::os::raw::c_int> ) ));
 }
 #[test]
-fn __bindgen_test_layout_Opaque_instantiation() {
+fn __bindgen_test_layout_Opaque_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<u32>() , 4usize , concat ! (
                "Size of template specialization: " , stringify ! ( u32 ) ));
     assert_eq!(::std::mem::align_of::<u32>() , 4usize , concat ! (

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -124,7 +124,7 @@ impl Default for Bar {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[test]
-fn __bindgen_test_layout_mozilla_StyleShapeSource_instantiation() {
+fn __bindgen_test_layout_mozilla_StyleShapeSource_open0_int_close0_instantiation() {
     assert_eq!(::std::mem::size_of::<mozilla_StyleShapeSource>() , 8usize ,
                concat ! (
                "Size of template specialization: " , stringify ! (


### PR DESCRIPTION
These numbers cause tons of churn in the diffs for checked in bindings.


r? @fitzgen