### PR TITLE
Remove RUST_LOG=bindgen from the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Thanks for filing a bindgen issue! We appreciate it :-) -->
+
 ### Input C/C++ Header
 
 ```C++
@@ -57,14 +59,3 @@ Replace this with a description of what you expected instead of the actual
 results. The more precise, the better! For example, if a struct in the generated
 bindings is missing a field that exists in the C/C++ struct, note that here.
 -->
-
-### `RUST_LOG=bindgen` Output
-
-<details>
-
-```
-Insert debug logging when running bindgen (not when compiling bindgen's output)
-with the `RUST_LOG=bindgen` environment variable set.
-```
-
-</details>


### PR DESCRIPTION
Neither Emilio nor I find it helpful, so lets rm -rf