### PR TITLE
Bump to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "bindgen"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "bindgen"
 readme = "README.md"
 repository = "https://github.com/servo/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-version = "0.27.0"
+version = "0.28.0"
 build = "build.rs"
 
 exclude = [


### PR DESCRIPTION
Brings in  #822 which unblocks https://bugzilla.mozilla.org/show_bug.cgi?id=1366956,
and also #829 which should greatly reduce merge conflicts in checked in bindings.